### PR TITLE
Make aif2pcm usable with foreign aif files.

### DIFF
--- a/tools/aif2pcm/extended.c
+++ b/tools/aif2pcm/extended.c
@@ -27,6 +27,7 @@
 
 #include <math.h>
 #include <string.h>
+#include <stdint.h>
 
 /*
  * Infinite & NAN values
@@ -62,7 +63,7 @@
  * Write IEEE Extended Precision Numbers
  */
 void
-ieee754_write_extended(double in, unsigned char* out)
+ieee754_write_extended(double in, uint8_t* out)
 {
 	int sgn, exp, shift;
 	double fraction, t;
@@ -114,17 +115,17 @@ done:
 	hexp = ((unsigned int) exp) & 0xFF;
 
 	/* big endian */
-	out[0] = ((unsigned char) sgn) << 7;
-	out[0] |= (unsigned char) lexp;
-	out[1] = (unsigned char) hexp;
-	out[2] = (unsigned char) (low >> 24);
-	out[3] = (unsigned char) ((low >> 16) & 0xFF);
-	out[4] = (unsigned char) ((low >> 8) & 0xFF);
-	out[5] = (unsigned char) (low & 0xFF);
-	out[6] = (unsigned char) (high >> 24);
-	out[7] = (unsigned char) ((high >> 16) & 0xFF);
-	out[8] = (unsigned char) ((high >> 8) & 0xFF);
-	out[9] = (unsigned char) (high & 0xFF);
+	out[0] = ((uint8_t) sgn) << 7;
+	out[0] |= (uint8_t) lexp;
+	out[1] = (uint8_t) hexp;
+	out[2] = (uint8_t) (low >> 24);
+	out[3] = (uint8_t) ((low >> 16) & 0xFF);
+	out[4] = (uint8_t) ((low >> 8) & 0xFF);
+	out[5] = (uint8_t) (low & 0xFF);
+	out[6] = (uint8_t) (high >> 24);
+	out[7] = (uint8_t) ((high >> 16) & 0xFF);
+	out[8] = (uint8_t) ((high >> 8) & 0xFF);
+	out[9] = (uint8_t) (high & 0xFF);
 
 	return;
 }
@@ -134,7 +135,7 @@ done:
  * Read IEEE Extended Precision Numbers
  */
 double
-ieee754_read_extended(unsigned char* in)
+ieee754_read_extended(uint8_t* in)
 {
 	int sgn, exp;
 	unsigned long low, high;

--- a/tools/aif2pcm/main.c
+++ b/tools/aif2pcm/main.c
@@ -118,7 +118,7 @@ AifData *read_aif(uint8_t * aif_file_data, unsigned long aif_file_data_size)
 	unsigned long num_sample_frames = 0;
 
 	// Read all the Chunks to populate the AifData struct.
-	while (pos < aif_file_data_size)
+	while ((pos + 8) < aif_file_data_size)
 	{
 		// Read Chunk id
 		memcpy(chunk_name, aif_file_data + pos, 4);
@@ -128,6 +128,11 @@ AifData *read_aif(uint8_t * aif_file_data, unsigned long aif_file_data_size)
 		chunk_size |= (aif_file_data[pos++] << 16);
 		chunk_size |= (aif_file_data[pos++] <<  8);
 		chunk_size |=  aif_file_data[pos++];
+
+		if ((pos + chunk_size) > aif_file_data_size)
+		{
+			FATAL_ERROR("%s chunk at 0x%lx reached end of file before finishing\n", chunk_name, pos);
+		}
 
 		if (strcmp(chunk_name, "COMM") == 0)
 		{

--- a/tools/aif2pcm/main.c
+++ b/tools/aif2pcm/main.c
@@ -25,8 +25,8 @@
 #include <stdint.h>
 
 /* extended.c */
-void ieee754_write_extended (double, unsigned char*);
-double ieee754_read_extended (unsigned char*);
+void ieee754_write_extended (double, uint8_t*);
+double ieee754_read_extended (uint8_t*);
 
 #ifdef _MSC_VER
 
@@ -50,8 +50,8 @@ do                                          \
 
 typedef struct {
 	unsigned long num_samples;
-	char *samples;
-	unsigned char midi_note;
+	uint8_t *samples;
+	uint8_t midi_note;
 	unsigned long loop_offset;
 	double sample_rate;
 } AifData;
@@ -79,7 +79,7 @@ void change_file_extension(char *filename, const char *new_extension)
 	memcpy(dot + 1, new_extension, 3);
 }
 
-AifData *read_aif(char * aif_file_data, unsigned long aif_file_data_size)
+AifData *read_aif(uint8_t * aif_file_data, unsigned long aif_file_data_size)
 {
 	AifData *aif_data = (AifData *)malloc(sizeof(AifData));
 
@@ -99,7 +99,7 @@ AifData *read_aif(char * aif_file_data, unsigned long aif_file_data_size)
 	unsigned long whole_chunk_size = aif_file_data[pos++] << 24;
 	whole_chunk_size |= (aif_file_data[pos++] << 16);
 	whole_chunk_size |= (aif_file_data[pos++] <<  8);
-	whole_chunk_size |= (unsigned char)aif_file_data[pos++];
+	whole_chunk_size |= (uint8_t)aif_file_data[pos++];
 
 	unsigned long expected_whole_chunk_size = aif_file_data_size - 8;
 	if (whole_chunk_size != expected_whole_chunk_size)
@@ -132,7 +132,7 @@ AifData *read_aif(char * aif_file_data, unsigned long aif_file_data_size)
 		if (strcmp(chunk_name, "COMM") == 0)
 		{
 			short num_channels = (aif_file_data[pos++] << 8);
-			num_channels |= (unsigned char)aif_file_data[pos++];
+			num_channels |= (uint8_t)aif_file_data[pos++];
 			if (num_channels != 1)
 			{
 				FATAL_ERROR("numChannels (%d) in the COMM Chunk must be 1!\n", num_channels);
@@ -141,16 +141,16 @@ AifData *read_aif(char * aif_file_data, unsigned long aif_file_data_size)
 			num_sample_frames =  (aif_file_data[pos++] << 24);
 			num_sample_frames |= (aif_file_data[pos++] << 16);
 			num_sample_frames |= (aif_file_data[pos++] <<  8);
-			num_sample_frames |=  (unsigned char)aif_file_data[pos++];
+			num_sample_frames |=  (uint8_t)aif_file_data[pos++];
 
 			short sample_size = (aif_file_data[pos++] << 8);
-			sample_size |= (unsigned char)aif_file_data[pos++];
+			sample_size |= (uint8_t)aif_file_data[pos++];
 			if (sample_size != 8)
 			{
 				FATAL_ERROR("sampleSize (%d) in the COMM Chunk must be 8!\n", sample_size);
 			}
 
-			double sample_rate = ieee754_read_extended((unsigned char*)(aif_file_data + pos));
+			double sample_rate = ieee754_read_extended((uint8_t*)(aif_file_data + pos));
 			pos += 10;
 
 			aif_data->sample_rate = sample_rate;
@@ -158,7 +158,7 @@ AifData *read_aif(char * aif_file_data, unsigned long aif_file_data_size)
 		else if (strcmp(chunk_name, "MARK") == 0)
 		{
 			unsigned short num_markers = (aif_file_data[pos++] << 8);
-			num_markers |= (unsigned char)aif_file_data[pos++];
+			num_markers |= (uint8_t)aif_file_data[pos++];
 
 			unsigned long loop_start = 0;
 
@@ -166,15 +166,15 @@ AifData *read_aif(char * aif_file_data, unsigned long aif_file_data_size)
 			for (int i = 0; i < num_markers; i++)
 			{
 				unsigned short marker_id = (aif_file_data[pos++] << 8);
-				marker_id |= (unsigned char)aif_file_data[pos++];
+				marker_id |= (uint8_t)aif_file_data[pos++];
 
 				unsigned long marker_position = (aif_file_data[pos++] << 24);
 				marker_position |= (aif_file_data[pos++] << 16);
 				marker_position |= (aif_file_data[pos++] << 8);
-				marker_position |=  (unsigned char)aif_file_data[pos++];
+				marker_position |=  (uint8_t)aif_file_data[pos++];
 
 				// Marker id is a pascal-style string.
-				unsigned char marker_name_size = aif_file_data[pos++];
+				uint8_t marker_name_size = aif_file_data[pos++];
 				char *marker_name = (char *)malloc((marker_name_size + 1) * sizeof(char));
 				memcpy(marker_name, aif_file_data + pos, marker_name_size);
 				marker_name[marker_name_size] = '\0';
@@ -196,7 +196,7 @@ AifData *read_aif(char * aif_file_data, unsigned long aif_file_data_size)
 		}
 		else if (strcmp(chunk_name, "INST") == 0)
 		{
-			unsigned char midi_note = (unsigned char)aif_file_data[pos++];
+			uint8_t midi_note = (uint8_t)aif_file_data[pos++];
 
 			aif_data->midi_note = midi_note;
 
@@ -208,7 +208,7 @@ AifData *read_aif(char * aif_file_data, unsigned long aif_file_data_size)
 			// SKip offset and blockSize
 			pos += 8;
 
-			char *sample_data = (char *)malloc(num_sample_frames * sizeof(char));
+			uint8_t *sample_data = (uint8_t *)malloc(num_sample_frames * sizeof(uint8_t));
 			memcpy(sample_data, aif_file_data + pos, num_sample_frames);
 
 			aif_data->samples = sample_data;
@@ -263,7 +263,7 @@ void aif2pcm(const char *aif_filename)
 	fseek(aif_file, 0, SEEK_SET);
 
 	// Create buffer for samples.
-	char *aif_file_data = (char *)malloc(aif_file_length * sizeof(char));
+	uint8_t *aif_file_data = (uint8_t *)malloc(aif_file_length * sizeof(uint8_t));
 	if (!aif_file_data)
 	{
 		FATAL_ERROR("Failed to allocate buffer for aif file data!\n");
@@ -406,7 +406,7 @@ void pcm2aif(const char *pcm_filename, char base_note, long pitch_adjust, long l
 
 	// Common Chunk sampleRate
 	double sample_rate = pitch_adjust / 1024.0;
-	unsigned char sample_rate_buffer[10];
+	uint8_t sample_rate_buffer[10];
 	ieee754_write_extended(sample_rate, sample_rate_buffer);
 	for (int i = 0; i < 10; i++)
 	{

--- a/tools/aif2pcm/main.c
+++ b/tools/aif2pcm/main.c
@@ -159,6 +159,11 @@ AifData *read_aif(uint8_t * aif_file_data, unsigned long aif_file_data_size)
 			pos += 10;
 
 			aif_data->sample_rate = sample_rate;
+
+			if (aif_data->num_samples == 0)
+			{
+				aif_data->num_samples = num_sample_frames;
+			}
 		}
 		else if (strcmp(chunk_name, "MARK") == 0)
 		{


### PR DESCRIPTION
- ffmpeg would pad the output to 4 bytes, which caused reads past eof.
- If the size of a chunk contained any bytes over `0x7f`, they would be interpreted as `signed` in some environments. This must have been avoided by coincidence.
- Many aif files do not have chunks denoting loops. Assuming they did led to a bug that produced empty pcms.