### PR TITLE
make ROM match again with a lazy temporary fix

### DIFF
--- a/include/fieldmap.h
+++ b/include/fieldmap.h
@@ -167,6 +167,67 @@ struct MapObject
     /*0x14*/ struct Coords16 coords3;
     /*0x18*/ u8 mapobj_unk_18:4;
     /*0x18*/ u8 placeholder18:4;
+    /*0x19*/ u8 mapobj_unk_19;
+    /*0x1A*/ u8 mapobj_unk_1A;
+    /*0x1B*/ u8 mapobj_unk_1B;
+    /*0x1C*/ u8 mapobj_unk_1C;
+    /*0x1D*/ u8 trainerRange_berryTreeId;
+    /*0x1E */ u8 mapobj_unk_1E;
+    /*0x1F*/ u8 mapobj_unk_1F;
+    /*0x20*/ u8 mapobj_unk_20;
+    /*0x21*/ u8 mapobj_unk_21;
+    /*size = 0x24*/
+};
+
+// THIS IS NEEDED TO MAKE TRAINER_SEE.C MATCH, PLEASE DO NOT REMOVE UNLESS YOU FIX CHECKPATHBETWEENTRAINERANDPLAYER
+struct MapObject2
+{
+    /*0x00*/ u32 active:1;
+             u32 mapobj_bit_1:1;
+             u32 mapobj_bit_2:1;
+             u32 mapobj_bit_3:1;
+             u32 mapobj_bit_4:1;
+             u32 mapobj_bit_5:1;
+             u32 mapobj_bit_6:1;
+             u32 mapobj_bit_7:1;
+    /*0x01*/ u32 mapobj_bit_8:1;
+             u32 mapobj_bit_9:1;
+             u32 mapobj_bit_10:1;
+             u32 mapobj_bit_11:1;
+             u32 mapobj_bit_12:1;
+             u32 mapobj_bit_13:1;
+             u32 mapobj_bit_14:1;
+             u32 mapobj_bit_15:1;
+    /*0x02*/ u32 mapobj_bit_16:1;
+             u32 mapobj_bit_17:1;
+             u32 mapobj_bit_18:1;
+             u32 mapobj_bit_19:1;
+             u32 mapobj_bit_20:1;
+             u32 mapobj_bit_21:1;
+             u32 mapobj_bit_22:1;
+             u32 mapobj_bit_23:1;
+    /*0x03*/ u32 mapobj_bit_24:1;
+             u32 mapobj_bit_25:1;
+             u32 mapobj_bit_26:1;
+             u32 mapobj_bit_27:1;
+             u32 mapobj_bit_28:1;
+             u32 mapobj_bit_29:1;
+             u32 mapobj_bit_30:1;
+             u32 mapobj_bit_31:1;
+    /*0x04*/ u8 spriteId;
+    /*0x05*/ u8 graphicsId;
+    /*0x06*/ u8 animPattern;
+    /*0x07*/ u8 trainerType;
+    /*0x08*/ u8 localId;
+    /*0x09*/ u8 mapNum;
+    /*0x0A*/ u8 mapGroup;
+    /*0x0B*/ u8 mapobj_unk_0B_0:4;
+             u8 elevation:4;
+    /*0x0C*/ struct Coords16 coords1;
+    /*0x10*/ struct Coords16 coords2;
+    /*0x14*/ struct Coords16 coords3;
+    /*0x18*/ u8 mapobj_unk_18:4;
+    /*0x18*/ u8 placeholder18:4;
     /*0x19*/ u8 mapobj_unk_19:4;
     /*0x19*/ u8 mapobj_unk_19b:4;
     /*0x1A*/ u8 mapobj_unk_1A;

--- a/src/trainer_see.c
+++ b/src/trainer_see.c
@@ -31,7 +31,7 @@ extern bool8 (*gTrainerSeeFuncList2[])(u8, struct Task *, struct MapObject *);
 extern u32 gUnknown_0202FF84[];
 
 bool8 CheckTrainer(u8);
-bool8 CheckPathBetweenTrainerAndPlayer(struct MapObject *, u8, u8);
+bool8 CheckPathBetweenTrainerAndPlayer(struct MapObject2 *, u8, u8);
 void sub_80842C8(struct MapObject *, u8);
 void RunTrainerSeeFuncList(u8);
 void sub_80847D8(u8);
@@ -138,7 +138,7 @@ bool8 IsTrainerInRangeEast(struct MapObject *trainerObj, s16 vision, s16 x, s16 
         return FALSE;
 }
 
-bool8 CheckPathBetweenTrainerAndPlayer(struct MapObject *trainerObj, u8 playerCoord, u8 direction)
+bool8 CheckPathBetweenTrainerAndPlayer(struct MapObject2 *trainerObj, u8 playerCoord, u8 direction)
 {
     s16 x, y;
     u8 unk19_temp;


### PR DESCRIPTION
emphasis on lazy. Had to make a duplicate MapObject struct that trainer_see.c uses solely. If you can fix CheckPathBetweenTrainerAndPlayer, PLEASE REMOVE THIS STRUCT.