### PR TITLE
Mark header files as the correct language for GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,4 @@ Makefile text eol=lf
 *.bin binary
 
 *.h linguist-language=C
+*.inc linguist-language=Assembly

--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,5 @@ Makefile text eol=lf
 
 *.png binary
 *.bin binary
+
+*.h linguist-language=C


### PR DESCRIPTION
This should make Github see our header files in this repository as C instead of C++, and our .inc files as Assembly instead of Pascal and PHP.