### PR TITLE
add LDFLAGS variable to tools makefiles

### DIFF
--- a/tools/aif2pcm/Makefile
+++ b/tools/aif2pcm/Makefile
@@ -9,7 +9,7 @@ SRCS = main.c extended.c
 .PHONY: clean
 
 aif2pcm: $(SRCS)
-	$(CC) $(CFLAGS) $(SRCS) -o $@ $(LIBS)
+	$(CC) $(CFLAGS) $(SRCS) -o $@ $(LDFLAGS) $(LIBS)
 
 clean:
 	$(RM) aif2pcm aif2pcm.exe

--- a/tools/aif2pcm/Makefile
+++ b/tools/aif2pcm/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 
-CFLAGS = -Wall -Wextra -Wno-switch -std=c11 -O2
+CFLAGS = -Wall -Wextra -Wno-switch -std=c11 -O2 -s
 
 LIBS = -lm
 

--- a/tools/bin2c/Makefile
+++ b/tools/bin2c/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 
-CFLAGS = -Wall -Wextra -std=c11 -O2
+CFLAGS = -Wall -Wextra -std=c11 -O2 -s
 
 .PHONY: clean
 

--- a/tools/bin2c/Makefile
+++ b/tools/bin2c/Makefile
@@ -7,7 +7,7 @@ CFLAGS = -Wall -Wextra -std=c11 -O2
 SRCS = bin2c.c
 
 bin2c: $(SRCS)
-	$(CC) $(CFLAGS) $(SRCS) -o $@
+	$(CC) $(CFLAGS) $(SRCS) -o $@ $(LDFLAGS)
 
 clean:
 	$(RM) bin2c bin2c.exe

--- a/tools/gbagfx/Makefile
+++ b/tools/gbagfx/Makefile
@@ -9,7 +9,7 @@ SRCS = main.c convert_png.c gfx.c jasc_pal.c lz.c rl.c util.c font.c
 .PHONY: clean
 
 gbagfx: $(SRCS) convert_png.h gfx.h global.h jasc_pal.h lz.h rl.h util.h font.h
-	$(CC) $(CFLAGS) $(SRCS) -o $@ $(LIBS)
+	$(CC) $(CFLAGS) $(SRCS) -o $@ $(LDFLAGS) $(LIBS)
 
 clean:
 	$(RM) gbagfx gbagfx.exe

--- a/tools/gbagfx/Makefile
+++ b/tools/gbagfx/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 
-CFLAGS = -Wall -Wextra -std=c11 -O2 -DPNG_SKIP_SETJMP_CHECK
+CFLAGS = -Wall -Wextra -std=c11 -O2 -s -DPNG_SKIP_SETJMP_CHECK
 
 LIBS = -lpng -lz
 

--- a/tools/mid2agb/Makefile
+++ b/tools/mid2agb/Makefile
@@ -9,7 +9,7 @@ HEADERS := agb.h error.h main.h midi.h tables.h
 .PHONY: clean
 
 mid2agb: $(SRCS) $(HEADERS)
-	$(CXX) $(CXXFLAGS) $(SRCS) -o $@
+	$(CXX) $(CXXFLAGS) $(SRCS) -o $@ $(LDFLAGS)
 
 clean:
 	$(RM) mid2agb mid2agb.exe

--- a/tools/mid2agb/Makefile
+++ b/tools/mid2agb/Makefile
@@ -1,6 +1,6 @@
 CXX := g++
 
-CXXFLAGS := -std=c++11 -O2 -Wall -Wno-switch
+CXXFLAGS := -std=c++11 -O2 -s -Wall -Wno-switch
 
 SRCS := agb.cpp error.cpp main.cpp midi.cpp tables.cpp
 

--- a/tools/preproc/Makefile
+++ b/tools/preproc/Makefile
@@ -11,7 +11,7 @@ HEADERS := asm_file.h c_file.h char_util.h charmap.h preproc.h string_parser.h \
 .PHONY: clean
 
 preproc: $(SRCS) $(HEADERS)
-	$(CXX) $(CXXFLAGS) $(SRCS) -o $@
+	$(CXX) $(CXXFLAGS) $(SRCS) -o $@ $(LDFLAGS)
 
 clean:
 	$(RM) preproc preproc.exe

--- a/tools/preproc/Makefile
+++ b/tools/preproc/Makefile
@@ -1,6 +1,6 @@
 CXX := g++
 
-CXXFLAGS := -std=c++11 -O2 -Wall -Wno-switch
+CXXFLAGS := -std=c++11 -O2 -s -Wall -Wno-switch
 
 SRCS := asm_file.cpp c_file.cpp charmap.cpp preproc.cpp string_parser.cpp \
 	utf8.cpp

--- a/tools/ramscrgen/Makefile
+++ b/tools/ramscrgen/Makefile
@@ -1,6 +1,6 @@
 CXX := g++
 
-CXXFLAGS := -std=c++11 -O2 -Wall -Wno-switch
+CXXFLAGS := -std=c++11 -O2 -s -Wall -Wno-switch
 
 SRCS := main.cpp sym_file.cpp elf.cpp
 

--- a/tools/ramscrgen/Makefile
+++ b/tools/ramscrgen/Makefile
@@ -9,7 +9,7 @@ HEADERS := ramscrgen.h sym_file.h elf.h char_util.h
 .PHONY: clean
 
 ramscrgen: $(SRCS) $(HEADERS)
-	$(CXX) $(CXXFLAGS) $(SRCS) -o $@
+	$(CXX) $(CXXFLAGS) $(SRCS) -o $@ $(LDFLAGS)
 
 clean:
 	$(RM) ramscrgen ramscrgen.exe

--- a/tools/rsfont/Makefile
+++ b/tools/rsfont/Makefile
@@ -9,7 +9,7 @@ SRCS = main.c convert_png.c util.c font.c
 .PHONY: clean
 
 rsfont: $(SRCS) convert_png.h gfx.h global.h util.h font.h
-	$(CC) $(CFLAGS) $(SRCS) -o $@ $(LIBS)
+	$(CC) $(CFLAGS) $(SRCS) -o $@ $(LDFLAGS) $(LIBS)
 
 clean:
 	$(RM) rsfont rsfont.exe

--- a/tools/rsfont/Makefile
+++ b/tools/rsfont/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 
-CFLAGS = -Wall -Wextra -std=c11 -O2 -DPNG_SKIP_SETJMP_CHECK
+CFLAGS = -Wall -Wextra -std=c11 -O2 -s -DPNG_SKIP_SETJMP_CHECK
 
 LIBS = -lpng -lz
 

--- a/tools/scaninc/Makefile
+++ b/tools/scaninc/Makefile
@@ -9,7 +9,7 @@ HEADERS := scaninc.h asm_file.h c_file.h
 .PHONY: clean
 
 scaninc: $(SRCS) $(HEADERS)
-	$(CXX) $(CXXFLAGS) $(SRCS) -o $@
+	$(CXX) $(CXXFLAGS) $(SRCS) -o $@ $(LDFLAGS)
 
 clean:
 	$(RM) scaninc scaninc.exe

--- a/tools/scaninc/Makefile
+++ b/tools/scaninc/Makefile
@@ -1,6 +1,6 @@
 CXX = g++
 
-CXXFLAGS = -Wall -std=c++11 -O2
+CXXFLAGS = -Wall -std=c++11 -O2 -s
 
 SRCS = scaninc.cpp c_file.cpp asm_file.cpp
 


### PR DESCRIPTION
This is mainly to make it easier to build redistributable Windows binaries. Running `LDFLAGS=-static ./build_tools` will build static versions of the tools that don't depend on any external DLLs.