### PR TITLE
Improvements for Mid2Agb

### DIFF
--- a/tools/mid2agb/error.cpp
+++ b/tools/mid2agb/error.cpp
@@ -22,7 +22,8 @@
 #include <cstdlib>
 #include <cstdarg>
 
-// Reports an error diagnostic and terminates the program.
+// Reports an error diagnostic and terminates the program
+// after the user presses Enter.
 [[noreturn]] void RaiseError(const char* format, ...)
 {
     const int bufferSize = 1024;
@@ -30,7 +31,12 @@
     std::va_list args;
     va_start(args, format);
     std::vsnprintf(buffer, bufferSize, format, args);
-    std::fprintf(stderr, "error: %s\n", buffer);
+    std::fprintf(stderr, "Error: %s\n", buffer);
     va_end(args);
+	// If the user drags a MIDI from File Explorer, 
+	// the console window would close before you could
+	// read it. 
+	std::printf("Press ENTER to continue...");
+	std::getchar();
     std::exit(1);
 }


### PR DESCRIPTION
Some improvements for Mid2Agb:

* Better support for drag and drop
* Support for filenames with spaces. This is also important for drag and drop because otherwise the ASM label would be something like "C:\Users\easyaspi314\pokeruby\tools\mid2agb\my midi file with spaces", and you can't have spaces in labels.
* Support for gba_mus_riper looping. gba_mus_riper uses loopStart and loopEnd instead of [ and ].
* Reveal -L option in usage. For the reference, it sets the ASM label.
* Header in usage message with program name and copyright.
* Slightly better grammar in error messages. Mainly just capitalization
* Pause on error. This allows you to actually see the error if you drag and drop. You need to press Enter to close it now.
* Not mentioned in the commit, but I added a few comments. 