### PR TITLE
fix scaninc buffer overflow crash

### DIFF
--- a/tools/scaninc/asm_file.cpp
+++ b/tools/scaninc/asm_file.cpp
@@ -137,7 +137,7 @@ std::string AsmFile::ReadPath()
             FATAL_INPUT_ERROR("path is too long");
     }
 
-    return std::string(m_buffer, startPos, length);
+    return std::string(m_buffer + startPos, length);
 }
 
 void AsmFile::SkipEndOfLineComment()


### PR DESCRIPTION
The constructor `std::string (const std::string& str, size_t pos, size_t len = npos);` takes a `std::string&` as its first argument. This causes the unterminated `m_buffer` to be implicitly converted to a string, and calling strlen in the process to determine the length of the string. This causes a crash when building pokeemerald. The other constructor `std::string (const char* s, size_t n);` does not implicitly create a string object, so it is safe to pass in `m_buffer` to it.