### PR TITLE
Script constants

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -229,10 +229,10 @@
 	@ Generic compare macro which attempts to deduce argument types based on their values
 	@ Any values between 0x4000 to 0x4FFF and 0x8000 to 0x8FFF are considered event variable identifiers
 	.macro compare arg1, arg2
-		.if ((\arg1 >> 12) == 4 || (\arg1 >> 12) == 8) && ((\arg2 >> 12) == 4 || (\arg2 >> 12) == 8)
-			compare_var_to_var \arg1, \arg2
-		.elseif ((\arg1 >> 12) == 4 || (\arg1 >> 12) == 8) && (\arg2 >= -0xFFFF && \arg2 <= 0xFFFF)
-			compare_var_to_value \arg1, (\arg2 & 0xFFFF)
+		.if (((\arg1) >> 12) == 4 || ((\arg1) >> 12) == 8) && (((\arg2) >> 12) == 4 || ((\arg2) >> 12) == 8)
+			compare_var_to_var (\arg1), (\arg2)
+		.elseif (((\arg1) >> 12) == 4 || ((\arg1) >> 12) == 8) && ((\arg2) >= -0xFFFF && (\arg2) <= 0xFFFF)
+			compare_var_to_value (\arg1), ((\arg2) & 0xFFFF)
 		.else
 			.error "Invalid arguments for 'compare'"
 		.endif

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -231,8 +231,8 @@
 	.macro compare arg1, arg2
 		.if ((\arg1 >> 12) == 4 || (\arg1 >> 12) == 8) && ((\arg2 >> 12) == 4 || (\arg2 >> 12) == 8)
 			compare_var_to_var \arg1, \arg2
-		.elseif ((\arg1 >> 12) == 4 || (\arg1 >> 12) == 8) && (\arg2 >= 0 && \arg2 <= 0xFFFF)
-			compare_var_to_value \arg1, \arg2
+		.elseif ((\arg1 >> 12) == 4 || (\arg1 >> 12) == 8) && (\arg2 >= -0xFFFF && \arg2 <= 0xFFFF)
+			compare_var_to_value \arg1, (\arg2 & 0xFFFF)
 		.else
 			.error "Invalid arguments for 'compare'"
 		.endif

--- a/data-de/event_scripts.s
+++ b/data-de/event_scripts.s
@@ -396,13 +396,13 @@ gStdScripts_End::
 
 gUnknown_0815F36C:: @ 815F36C
 	lockall
-	playse 2
+	playse SE_PC_LOGON
 	message UnknownString_81A3A72
 	dofieldeffect 61
 	waitstate
 	waitmessage
 	waitbuttonpress
-	playse 5
+	playse SE_SELECT
 	goto EventScript_15F384
 	end
 
@@ -458,12 +458,12 @@ EventScript_15F436:
 gUnknown_0815F43A:: @ 815F43A
 	lockall
 	message UnknownString_81A3A72
-	playse 2
+	playse SE_PC_LOGON
 	dofieldeffect 61
 	waitstate
 	waitmessage
 	waitbuttonpress
-	playse 5
+	playse SE_SELECT
 	goto EventScript_15F452
 	end
 
@@ -1572,11 +1572,11 @@ Std_ObtainItem_Fail: @ 819FECC
 	return
 
 PlayGetItemFanfare:
-	playfanfare 0x172
+	playfanfare BGM_FANFA4
 	return
 
 PlayGetTMHMFanfare:
-	playfanfare 0x174
+	playfanfare BGM_ME_WAZA
 	return
 
 Std_ObtainDecoration: @ 819FEDA
@@ -1594,7 +1594,7 @@ Std_ObtainDecoration_: @ 819FEE8
 	return
 
 Std_ObtainDecoration_Success: @ 819FF03
-	playfanfare 0x172
+	playfanfare BGM_FANFA4
 	message Message_ObtainedDecoration
 	waitfanfare
 	waitmessage
@@ -1691,7 +1691,7 @@ gUnknown_081A0009:: @ 81A0009
 	lockall
 	setvar VAR_SPECIAL_4, 0
 	special DoPCTurnOnEffect
-	playse 4
+	playse SE_PC_ON
 	msgbox UnknownString_81A09EC, 4
 	goto EventScript_1A0023
 	end
@@ -1714,7 +1714,7 @@ EventScript_1A0033:
 	end
 
 EventScript_1A0070:
-	playse 2
+	playse SE_PC_LOGON
 	msgbox UnknownString_81A0A54, 4
 	special PlayerPC
 	waitstate
@@ -1722,7 +1722,7 @@ EventScript_1A0070:
 	end
 
 EventScript_1A0085:
-	playse 2
+	playse SE_PC_LOGON
 	checkflag FLAG_SYS_PC_LANETTE
 	call_if 0, EventScript_1A00AC
 	checkflag FLAG_SYS_PC_LANETTE
@@ -1743,7 +1743,7 @@ EventScript_1A00B5:
 
 EventScript_1A00BE:
 	setvar VAR_SPECIAL_4, 0
-	playse 3
+	playse SE_PC_OFF
 	special DoPCTurnOffEffect
 	releaseall
 	end
@@ -1751,7 +1751,7 @@ EventScript_1A00BE:
 EventScript_1A00CB:
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_if 0, EventScript_1A00BE
-	playse 2
+	playse SE_PC_LOGON
 	special AccessHallOfFamePC
 	waitstate
 	goto EventScript_1A0033
@@ -2111,7 +2111,7 @@ MossdeepCity_Gym_EventScript_1A02C5:: @ 81A02C5
 PetalburgCity_Gym_EventScript_1A02C5:: @ 81A02C5
 RustboroCity_Gym_EventScript_1A02C5:: @ 81A02C5
 SootopolisCity_Gym_1F_EventScript_1A02C5:: @ 81A02C5
-	playfanfare 369
+	playfanfare BGM_ME_BACHI
 	waitfanfare
 	return
 
@@ -2120,7 +2120,7 @@ Route111_OldLadysRestStop_EventScript_1A02CA:: @ 81A02CA
 Route119_WeatherInstitute_1F_EventScript_1A02CA:: @ 81A02CA
 SSTidalRooms_EventScript_1A02CA:: @ 81A02CA
 	fadescreen 1
-	playfanfare 368
+	playfanfare BGM_ME_ASA
 	waitfanfare
 	special ScrSpecial_HealPlayerParty
 	fadescreen 0
@@ -2139,7 +2139,7 @@ DewfordTown_EventScript_1A02E7:: @ 81A02E7
 Route104_EventScript_1A02E7:: @ 81A02E7
 Route109_EventScript_1A02E7:: @ 81A02E7
 	setflag FLAG_SPECIAL_FLAG_1
-	playbgm 431, 0
+	playbgm BGM_M_BOAT, FALSE
 	return
 
 DewfordTown_EventScript_1A02EF:: @ 81A02EF
@@ -2553,7 +2553,7 @@ GraniteCave_StevensRoom_EventScript_1A067F:: @ 81A067F
 MtPyre_Summit_EventScript_1A067F:: @ 81A067F
 SlateportCity_OceanicMuseum_2F_EventScript_1A067F:: @ 81A067F
 	bufferitemname 0, VAR_SPECIAL_4
-	playfanfare 372
+	playfanfare BGM_ME_WAZA
 	message FallarborTown_House1_Text_1A1498
 	waitmessage
 	waitfanfare
@@ -2566,7 +2566,7 @@ EverGrandeCity_PhoebesRoom_EventScript_1A0693:: @ 81A0693
 EverGrandeCity_SidneysRoom_EventScript_1A0693:: @ 81A0693
 	applymovement 255, EverGrandeCity_SidneysRoom_Movement_1A0853
 	waitmovement 0
-	playse 8
+	playse SE_DOOR
 	setmetatile 6, 1, 836, 0
 	setmetatile 6, 2, 837, 0
 	setmetatile 0, 2, 734, 1
@@ -2588,7 +2588,7 @@ EverGrandeCity_PhoebesRoom_EventScript_1A0710:: @ 81A0710
 EverGrandeCity_SidneysRoom_EventScript_1A0710:: @ 81A0710
 	applymovement 255, EverGrandeCity_SidneysRoom_Movement_1A0847
 	waitmovement 0
-	playse 52
+	playse SE_TRACK_DOOR
 	setmetatile 5, 12, 518, 1
 	setmetatile 6, 12, 518, 1
 	setmetatile 7, 12, 518, 1
@@ -3742,7 +3742,7 @@ EventScript_1A2DAA:
 
 EventScript_1A2DB8:
 	closemessage
-	playse 9
+	playse SE_KAIDAN
 	setvar VAR_0x4097, 0
 	setflag FLAG_DECORATION_1
 	special sub_80BB8CC
@@ -3762,7 +3762,7 @@ SecretBase_RedCave1_EventScript_1A2DDE:: @ 81A2DDE
 	compare RESULT, 1
 	goto_if_eq SecretBase_RedCave1_EventScript_1A2E08
 	closemessage
-	playse 9
+	playse SE_KAIDAN
 	special sub_80BC440
 	end
 
@@ -3781,7 +3781,7 @@ SecretBase_RedCave1_Movement_1A2E11:: @ 81A2E11
 gUnknown_081A2E14:: @ 81A2E14
 	lockall
 	setvar VAR_0x4097, 1
-	playse 9
+	playse SE_KAIDAN
 	special sub_80BC114
 	compare RESULT, 0
 	goto_if_eq EventScript_1A2E38
@@ -4915,7 +4915,7 @@ S_FallDownHole:: @ 81C6BC5
 	delay 20
 	applymovement 255, GraniteCave_B1F_Movement_1C6BF7
 	waitmovement 0
-	playse 43
+	playse SE_RU_HYUU
 	delay 60
 	warphole MAP_UNDEFINED
 	waitstate
@@ -4926,7 +4926,7 @@ gUnknown_081C6BDE:: @ 81C6BDE
 	delay 20
 	applymovement 255, GraniteCave_B1F_Movement_1C6BF7
 	waitmovement 0
-	playse 43
+	playse SE_RU_HYUU
 	delay 60
 	special sp13F_fall_to_last_warp
 	waitstate

--- a/data-de/event_scripts.s
+++ b/data-de/event_scripts.s
@@ -8,6 +8,7 @@
 #include "constants/opponents.h"
 #include "constants/songs.h"
 #include "constants/species.h"
+#include "constants/weather.h"
 #include "constants/vars.h"
 	.include "asm/macros.inc"
 	.include "asm/macros/event.inc"
@@ -2096,9 +2097,9 @@ Route127_EventScript_1A02C1:: @ 81A02C1
 Route128_EventScript_1A02C1:: @ 81A02C1
 SootopolisCity_EventScript_1A02C1:: @ 81A02C1
 	.ifdef SAPPHIRE
-	setweather 13
+	setweather WEATHER_RAIN_HEAVY
 	.else
-	setweather 12
+	setweather WEATHER_DROUGHT
 	.endif
 	return
 

--- a/data-de/event_scripts.s
+++ b/data-de/event_scripts.s
@@ -440,8 +440,8 @@ EventScript_15F3E2:
 	end
 
 EventScript_15F419:
-	msgbox UnknownString_81A38FB, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A38FB, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_15F384
 	closemessage
 	special SecretBasePC_PackUp
@@ -492,8 +492,8 @@ EventScript_15F4A1:
 	compare RESULT, 2
 	goto_if_eq EventScript_15F503
 	special BufferSecretBaseOwnerName
-	msgbox UnknownString_81A3958, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A3958, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_15F452
 	msgbox UnknownString_81A3A22, 3
 	special sub_80BC5BC
@@ -502,8 +502,8 @@ EventScript_15F4A1:
 	end
 
 EventScript_15F4E0:
-	msgbox UnknownString_81A3982, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A3982, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_15F452
 	msgbox UnknownString_81A3A3A, 3
 	special sub_80BC5BC
@@ -1449,10 +1449,10 @@ SootopolisCity_PokemonCenter_1F_EventScript_19FD5B:: @ 819FD5B
 VerdanturfTown_PokemonCenter_1F_EventScript_19FD5B:: @ 819FD5B
 	lock
 	faceplayer
-	msgbox gText_NurseJoy_Welcome, 5
-	compare RESULT, 1
+	msgbox gText_NurseJoy_Welcome, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq OldaleTown_PokemonCenter_1F_EventScript_19FD7C
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq OldaleTown_PokemonCenter_1F_EventScript_19FDC7
 	end
 
@@ -1670,10 +1670,10 @@ HiddenItemScript_Fail:
 UnusedMixRecordsScript: @ 819FFD5
 	lock
 	faceplayer
-	msgbox UnusedMixRecordsPromptText, 5
-	compare RESULT, 1
+	msgbox UnusedMixRecordsPromptText, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq UnusedMixRecordsScript_Yes
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq UnusedMixRecordsScript_Done
 	goto UnusedMixRecordsScript_Done
 UnusedMixRecordsScript_Yes: @ 819FFFA
@@ -1833,8 +1833,8 @@ UseSurfScript:: @ 81A0117
 	bufferpartymonnick 0, RESULT
 	setfieldeffectargument 0, RESULT
 	lockall
-	msgbox UseSurfPromptText, 5
-	compare RESULT, 0
+	msgbox UseSurfPromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq UseSurfScript_No
 	msgbox UsedSurfText, 4
 	dofieldeffect 9
@@ -2199,8 +2199,8 @@ Route101_EventScript_1A037F:: @ 81A037F
 Route103_EventScript_1A037F:: @ 81A037F
 	lock
 	faceplayer
-	msgbox Route101_Text_1C4449, 5
-	compare RESULT, 0
+	msgbox Route101_Text_1C4449, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route101_EventScript_1A039B
 	call Route101_EventScript_1A03B0
 	release
@@ -2448,8 +2448,8 @@ Route120_EventScript_1A0594:: @ 81A0594
 	end
 
 Route119_EventScript_1A05AE:: @ 81A05AE
-	msgbox Route119_Text_171BB6, 5
-	compare RESULT, 1
+	msgbox Route119_Text_171BB6, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route119_EventScript_1A05C3
 	release
 	end
@@ -3653,8 +3653,8 @@ EventScript_1A2CB0:
 	compare RESULT, 6
 	goto_if_eq EventScript_1A2CF1
 	bufferpartymonnick 0, RESULT
-	msgbox UnknownString_8198F34, 5
-	compare RESULT, 0
+	msgbox UnknownString_8198F34, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_1A2F3A
 	msgbox UsedCutRockSmashText, 4
 	closemessage
@@ -3684,8 +3684,8 @@ EventScript_1A2D08:
 	compare RESULT, 6
 	goto_if_eq EventScript_1A2D49
 	bufferpartymonnick 0, RESULT
-	msgbox UnknownString_81A197B, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A197B, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_1A2F3A
 	msgbox UsedCutRockSmashText, 4
 	closemessage
@@ -3715,8 +3715,8 @@ EventScript_1A2D60:
 	compare RESULT, 6
 	goto_if_eq EventScript_1A2DA1
 	bufferpartymonnick 0, RESULT
-	msgbox UnknownString_81A1A4B, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A1A4B, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_1A2F3A
 	msgbox UsedCutRockSmashText, 4
 	closemessage
@@ -3759,8 +3759,8 @@ SecretBase_RedCave1_EventScript_1A2DDE:: @ 81A2DDE
 	applymovement 255, SecretBase_RedCave1_Movement_1A2E11
 	waitmovement 0
 	setvar VAR_0x4097, 1
-	msgbox SecretBase_RedCave1_Text_198F89, 5
-	compare RESULT, 1
+	msgbox SecretBase_RedCave1_Text_198F89, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SecretBase_RedCave1_EventScript_1A2E08
 	closemessage
 	playse SE_KAIDAN
@@ -3807,18 +3807,18 @@ EventScript_1A2E45:
 	setorcopyvar VAR_SPECIAL_4, RESULT
 	lockall
 	special GetSecretBaseNearbyMapName
-	msgbox UnknownString_81A3C71, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A3C71, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_1A2F3A
-	msgbox UnknownString_81A38FB, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A38FB, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_1A2F3A
 	fadescreen 1
 	special MoveSecretBase
 	closemessage
 	fadescreen 0
-	msgbox UnknownString_81A3CC9, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A3CC9, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_1A2F3A
 	bufferpartymonnick 0, VAR_SPECIAL_4
 	buffermovename 1, MOVE_SECRET_POWER
@@ -3971,8 +3971,8 @@ SecretBase_RedCave1_EventScript_1A3032:: @ 81A3032
 	goto_if_eq SecretBase_RedCave1_EventScript_1A30A5
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A1AEA, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A1AEA, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A308F
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4006,8 +4006,8 @@ SecretBase_RedCave1_EventScript_1A30AE:: @ 81A30AE
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3121
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A1E67, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A1E67, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A310B
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4041,8 +4041,8 @@ SecretBase_RedCave1_EventScript_1A312A:: @ 81A312A
 	goto_if_eq SecretBase_RedCave1_EventScript_1A319D
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A218F, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A218F, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3187
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4076,8 +4076,8 @@ SecretBase_RedCave1_EventScript_1A31A6:: @ 81A31A6
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3219
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A24E1, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A24E1, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3203
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4111,8 +4111,8 @@ SecretBase_RedCave1_EventScript_1A3222:: @ 81A3222
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3295
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A2830, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A2830, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A327F
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4146,8 +4146,8 @@ SecretBase_RedCave1_EventScript_1A329E:: @ 81A329E
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3311
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A1CB2, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A1CB2, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A32FB
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4181,8 +4181,8 @@ SecretBase_RedCave1_EventScript_1A331A:: @ 81A331A
 	goto_if_eq SecretBase_RedCave1_EventScript_1A338D
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A2026, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A2026, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3377
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4216,8 +4216,8 @@ SecretBase_RedCave1_EventScript_1A3396:: @ 81A3396
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3409
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A236A, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A236A, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A33F3
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4251,8 +4251,8 @@ SecretBase_RedCave1_EventScript_1A3412:: @ 81A3412
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3485
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A2663, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A2663, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A346F
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4286,8 +4286,8 @@ SecretBase_RedCave1_EventScript_1A348E:: @ 81A348E
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3501
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A2A13, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A2A13, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A34EB
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4427,10 +4427,10 @@ SlateportCity_PokemonFanClub_EventScript_1ADE4D:: @ 81ADE4D
 	compare RESULT, 1
 	goto_if_eq SlateportCity_PokemonFanClub_EventScript_1ADED6
 	copyvar VAR_SPECIAL_9, VAR_SPECIAL_6
-	msgbox SlateportCity_PokemonFanClub_Text_1A8704, 5
-	compare RESULT, 1
+	msgbox SlateportCity_PokemonFanClub_Text_1A8704, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SlateportCity_PokemonFanClub_EventScript_1ADE84
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq SlateportCity_PokemonFanClub_EventScript_1ADEB9
 	end
 
@@ -4475,18 +4475,18 @@ SlateportCity_OceanicMuseum_1F_EventScript_1ADEE0:: @ 81ADEE0
 	checkflag FLAG_OCEANIC_MUSEUM_MET_REPORTER
 	goto_if_eq SlateportCity_OceanicMuseum_1F_EventScript_1ADF25
 	setflag FLAG_OCEANIC_MUSEUM_MET_REPORTER
-	msgbox SlateportCity_OceanicMuseum_1F_Text_1A927F, 5
-	compare RESULT, 1
+	msgbox SlateportCity_OceanicMuseum_1F_Text_1A927F, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SlateportCity_OceanicMuseum_1F_EventScript_1ADF44
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq SlateportCity_OceanicMuseum_1F_EventScript_1ADF79
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_1ADF25:: @ 81ADF25
-	msgbox SlateportCity_OceanicMuseum_1F_Text_1A934C, 5
-	compare RESULT, 1
+	msgbox SlateportCity_OceanicMuseum_1F_Text_1A934C, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SlateportCity_OceanicMuseum_1F_EventScript_1ADF44
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq SlateportCity_OceanicMuseum_1F_EventScript_1ADF79
 	end
 
@@ -4531,10 +4531,10 @@ SlateportCity_PokemonFanClub_EventScript_1ADFA0:: @ 81ADFA0
 	compare RESULT, 1
 	goto_if_eq SlateportCity_PokemonFanClub_EventScript_1AE0AC
 	copyvar VAR_SPECIAL_9, VAR_SPECIAL_6
-	msgbox SlateportCity_PokemonFanClub_Text_1A82F1, 5
-	compare RESULT, 1
+	msgbox SlateportCity_PokemonFanClub_Text_1A82F1, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SlateportCity_PokemonFanClub_EventScript_1ADFE9
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq SlateportCity_PokemonFanClub_EventScript_1AE0A2
 	end
 
@@ -4608,10 +4608,10 @@ VerdanturfTown_ContestLobby_EventScript_1AE0B6:: @ 81AE0B6
 	compare RESULT, 1
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1AE17E
 	copyvar VAR_SPECIAL_9, VAR_SPECIAL_6
-	msgbox FallarborTown_ContestLobby_Text_1A6F7C, 5
-	compare RESULT, 1
+	msgbox FallarborTown_ContestLobby_Text_1A6F7C, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1AE0F8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1AE12D
 	end
 
@@ -4705,10 +4705,10 @@ BattleTower_Lobby_EventScript_1AE1FF:: @ 81AE1FF
 	compare RESULT, 1
 	goto_if_eq BattleTower_Lobby_EventScript_1AE2E3
 	copyvar VAR_SPECIAL_9, VAR_SPECIAL_6
-	msgbox BattleTower_Lobby_Text_1A776D, 5
-	compare RESULT, 1
+	msgbox BattleTower_Lobby_Text_1A776D, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq BattleTower_Lobby_EventScript_1AE241
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq BattleTower_Lobby_EventScript_1AE297
 	end
 

--- a/data-de/field_move_scripts.inc
+++ b/data-de/field_move_scripts.inc
@@ -8,8 +8,8 @@ S_CuttableTree:: @ 81B0DCC
 	setfieldeffectargument 0, RESULT
 	bufferpartymonnick 0, RESULT
 	buffermovename 1, MOVE_CUT
-	msgbox UseCutPromptText, 5
-	compare RESULT, 0
+	msgbox UseCutPromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Cut_ChoseNo
 	msgbox UsedCutRockSmashText, 4
 	closemessage
@@ -69,8 +69,8 @@ S_BreakableRock:: @ 81B0EB7
 	setfieldeffectargument 0, RESULT
 	bufferpartymonnick 0, RESULT
 	buffermovename 1, MOVE_ROCK_SMASH
-	msgbox UseRockSmashPromptText, 5
-	compare RESULT, 0
+	msgbox UseRockSmashPromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq RockSmash_ChoseNo
 	msgbox UsedCutRockSmashText, 4
 	closemessage
@@ -136,8 +136,8 @@ S_PushableBoulder:: @ 81B0FCB
 	compare RESULT, 6
 	goto_if_eq CannotUseStrength
 	setfieldeffectargument 0, RESULT
-	msgbox UseStrengthPromptText, 5
-	compare RESULT, 0
+	msgbox UseStrengthPromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Strength_ChoseNo
 	closemessage
 	dofieldeffect 40
@@ -198,8 +198,8 @@ S_UseWaterfall:: @ 81B115A
 	goto_if_eq Waterfall_NoMonKnows
 	bufferpartymonnick 0, RESULT
 	setfieldeffectargument 0, RESULT
-	msgbox UseWaterfallPromptText, 5
-	compare RESULT, 0
+	msgbox UseWaterfallPromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Waterfall_Done
 	msgbox UsedWaterfallText, 4
 	dofieldeffect 43
@@ -232,8 +232,8 @@ UseDiveScript:: @ 81B1220
 	bufferpartymonnick 0, RESULT
 	setfieldeffectargument 0, RESULT
 	setfieldeffectargument 1, 1
-	msgbox UseDivePromptText, 5
-	compare RESULT, 0
+	msgbox UseDivePromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Dive_Done
 	msgbox UsedDiveText, 4
 	dofieldeffect 44
@@ -255,8 +255,8 @@ S_UseDiveUnderwater:: @ 81B1269
 	bufferpartymonnick 0, RESULT
 	setfieldeffectargument 0, RESULT
 	setfieldeffectargument 1, 1
-	msgbox UnderwaterUseDivePromptText, 5
-	compare RESULT, 0
+	msgbox UnderwaterUseDivePromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq UnderwaterDive_Done
 	msgbox UsedDiveText, 4
 	dofieldeffect 44

--- a/data/battle_scripts_2.s
+++ b/data/battle_scripts_2.s
@@ -164,7 +164,7 @@ BattleScript_OpponentUsesGuardSpecs: @ 81D9FBB
 	finishaction
 
 BattleScript_RunByUsingItem: @ 81D9FDA
-	playse 17
+	playse SE_NIGERU
 	setbyte gBattleOutcome, BATTLE_RAN
 	finishturn
 

--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -396,13 +396,13 @@ gStdScripts_End::
 
 gUnknown_0815F36C:: @ 815F36C
 	lockall
-	playse 2
+	playse SE_PC_LOGON
 	message UnknownString_81A3A72
 	dofieldeffect 61
 	waitstate
 	waitmessage
 	waitbuttonpress
-	playse 5
+	playse SE_SELECT
 	goto EventScript_15F384
 	end
 
@@ -458,12 +458,12 @@ EventScript_15F436:
 gUnknown_0815F43A:: @ 815F43A
 	lockall
 	message UnknownString_81A3A72
-	playse 2
+	playse SE_PC_LOGON
 	dofieldeffect 61
 	waitstate
 	waitmessage
 	waitbuttonpress
-	playse 5
+	playse SE_SELECT
 	goto EventScript_15F452
 	end
 
@@ -1566,11 +1566,11 @@ Std_ObtainItem_Fail: @ 819FECC
 	return
 
 PlayGetItemFanfare:
-	playfanfare 0x172
+	playfanfare BGM_FANFA4
 	return
 
 PlayGetTMHMFanfare:
-	playfanfare 0x174
+	playfanfare BGM_ME_WAZA
 	return
 
 Std_ObtainDecoration: @ 819FEDA
@@ -1588,7 +1588,7 @@ Std_ObtainDecoration_: @ 819FEE8
 	return
 
 Std_ObtainDecoration_Success: @ 819FF03
-	playfanfare 0x172
+	playfanfare BGM_FANFA4
 	message Message_ObtainedDecoration
 	waitfanfare
 	waitmessage
@@ -1685,7 +1685,7 @@ gUnknown_081A0009:: @ 81A0009
 	lockall
 	setvar VAR_SPECIAL_4, 0
 	special DoPCTurnOnEffect
-	playse 4
+	playse SE_PC_ON
 	msgbox UnknownString_81A09EC, 4
 	goto EventScript_1A0023
 	end
@@ -1708,7 +1708,7 @@ EventScript_1A0033:
 	end
 
 EventScript_1A0070:
-	playse 2
+	playse SE_PC_LOGON
 	msgbox UnknownString_81A0A54, 4
 	special PlayerPC
 	waitstate
@@ -1716,7 +1716,7 @@ EventScript_1A0070:
 	end
 
 EventScript_1A0085:
-	playse 2
+	playse SE_PC_LOGON
 	checkflag FLAG_SYS_PC_LANETTE
 	call_if 0, EventScript_1A00AC
 	checkflag FLAG_SYS_PC_LANETTE
@@ -1737,7 +1737,7 @@ EventScript_1A00B5:
 
 EventScript_1A00BE:
 	setvar VAR_SPECIAL_4, 0
-	playse 3
+	playse SE_PC_OFF
 	special DoPCTurnOffEffect
 	releaseall
 	end
@@ -1745,7 +1745,7 @@ EventScript_1A00BE:
 EventScript_1A00CB:
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_if 0, EventScript_1A00BE
-	playse 2
+	playse SE_PC_LOGON
 	special AccessHallOfFamePC
 	waitstate
 	goto EventScript_1A0033
@@ -2105,7 +2105,7 @@ MossdeepCity_Gym_EventScript_1A02C5:: @ 81A02C5
 PetalburgCity_Gym_EventScript_1A02C5:: @ 81A02C5
 RustboroCity_Gym_EventScript_1A02C5:: @ 81A02C5
 SootopolisCity_Gym_1F_EventScript_1A02C5:: @ 81A02C5
-	playfanfare 369
+	playfanfare BGM_ME_BACHI
 	waitfanfare
 	return
 
@@ -2114,7 +2114,7 @@ Route111_OldLadysRestStop_EventScript_1A02CA:: @ 81A02CA
 Route119_WeatherInstitute_1F_EventScript_1A02CA:: @ 81A02CA
 SSTidalRooms_EventScript_1A02CA:: @ 81A02CA
 	fadescreen 1
-	playfanfare 368
+	playfanfare BGM_ME_ASA
 	waitfanfare
 	special ScrSpecial_HealPlayerParty
 	fadescreen 0
@@ -2133,7 +2133,7 @@ DewfordTown_EventScript_1A02E7:: @ 81A02E7
 Route104_EventScript_1A02E7:: @ 81A02E7
 Route109_EventScript_1A02E7:: @ 81A02E7
 	setflag FLAG_SPECIAL_FLAG_1
-	playbgm 431, 0
+	playbgm BGM_M_BOAT, FALSE
 	return
 
 DewfordTown_EventScript_1A02EF:: @ 81A02EF
@@ -2547,7 +2547,7 @@ GraniteCave_StevensRoom_EventScript_1A067F:: @ 81A067F
 MtPyre_Summit_EventScript_1A067F:: @ 81A067F
 SlateportCity_OceanicMuseum_2F_EventScript_1A067F:: @ 81A067F
 	bufferitemname 0, VAR_SPECIAL_4
-	playfanfare 372
+	playfanfare BGM_ME_WAZA
 	message FallarborTown_House1_Text_1A1498
 	waitmessage
 	waitfanfare
@@ -2560,7 +2560,7 @@ EverGrandeCity_PhoebesRoom_EventScript_1A0693:: @ 81A0693
 EverGrandeCity_SidneysRoom_EventScript_1A0693:: @ 81A0693
 	applymovement 255, EverGrandeCity_SidneysRoom_Movement_1A0853
 	waitmovement 0
-	playse 8
+	playse SE_DOOR
 	setmetatile 6, 1, 836, 0
 	setmetatile 6, 2, 837, 0
 	setmetatile 0, 2, 734, 1
@@ -2582,7 +2582,7 @@ EverGrandeCity_PhoebesRoom_EventScript_1A0710:: @ 81A0710
 EverGrandeCity_SidneysRoom_EventScript_1A0710:: @ 81A0710
 	applymovement 255, EverGrandeCity_SidneysRoom_Movement_1A0847
 	waitmovement 0
-	playse 52
+	playse SE_TRACK_DOOR
 	setmetatile 5, 12, 518, 1
 	setmetatile 6, 12, 518, 1
 	setmetatile 7, 12, 518, 1
@@ -3721,7 +3721,7 @@ EventScript_1A2DAA:
 
 EventScript_1A2DB8:
 	closemessage
-	playse 9
+	playse SE_KAIDAN
 	setvar VAR_0x4097, 0
 	setflag FLAG_DECORATION_1
 	special sub_80BB8CC
@@ -3741,7 +3741,7 @@ SecretBase_RedCave1_EventScript_1A2DDE:: @ 81A2DDE
 	compare RESULT, 1
 	goto_if_eq SecretBase_RedCave1_EventScript_1A2E08
 	closemessage
-	playse 9
+	playse SE_KAIDAN
 	special sub_80BC440
 	end
 
@@ -3760,7 +3760,7 @@ SecretBase_RedCave1_Movement_1A2E11:: @ 81A2E11
 gUnknown_081A2E14:: @ 81A2E14
 	lockall
 	setvar VAR_0x4097, 1
-	playse 9
+	playse SE_KAIDAN
 	special sub_80BC114
 	compare RESULT, 0
 	goto_if_eq EventScript_1A2E38
@@ -4883,7 +4883,7 @@ S_FallDownHole:: @ 81C6BC5
 	delay 20
 	applymovement 255, GraniteCave_B1F_Movement_1C6BF7
 	waitmovement 0
-	playse 43
+	playse SE_RU_HYUU
 	delay 60
 	warphole MAP_UNDEFINED
 	waitstate
@@ -4894,7 +4894,7 @@ gUnknown_081C6BDE:: @ 81C6BDE
 	delay 20
 	applymovement 255, GraniteCave_B1F_Movement_1C6BF7
 	waitmovement 0
-	playse 43
+	playse SE_RU_HYUU
 	delay 60
 	special sp13F_fall_to_last_warp
 	waitstate

--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -440,8 +440,8 @@ EventScript_15F3E2:
 	end
 
 EventScript_15F419:
-	msgbox UnknownString_81A38FB, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A38FB, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_15F384
 	closemessage
 	special SecretBasePC_PackUp
@@ -492,8 +492,8 @@ EventScript_15F4A1:
 	compare RESULT, 2
 	goto_if_eq EventScript_15F503
 	special BufferSecretBaseOwnerName
-	msgbox UnknownString_81A3958, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A3958, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_15F452
 	msgbox UnknownString_81A3A22, 3
 	special sub_80BC5BC
@@ -502,8 +502,8 @@ EventScript_15F4A1:
 	end
 
 EventScript_15F4E0:
-	msgbox UnknownString_81A3982, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A3982, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_15F452
 	msgbox UnknownString_81A3A3A, 3
 	special sub_80BC5BC
@@ -1444,9 +1444,9 @@ VerdanturfTown_PokemonCenter_1F_EventScript_19FD5B:: @ 819FD5B
 	lock
 	faceplayer
 	msgbox gText_NurseJoy_Welcome, MSGBOX_YESNO
-	compare RESULT, 1
+	compare RESULT, YES
 	goto_if_eq do_heal_party
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq dont_heal_party
 	end
 
@@ -1664,10 +1664,10 @@ HiddenItemScript_Fail:
 UnusedMixRecordsScript: @ 819FFD5
 	lock
 	faceplayer
-	msgbox UnusedMixRecordsPromptText, 5
-	compare RESULT, 1
+	msgbox UnusedMixRecordsPromptText, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq UnusedMixRecordsScript_Yes
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq UnusedMixRecordsScript_Done
 	goto UnusedMixRecordsScript_Done
 UnusedMixRecordsScript_Yes: @ 819FFFA
@@ -1827,8 +1827,8 @@ UseSurfScript:: @ 81A0117
 	bufferpartymonnick 0, RESULT
 	setfieldeffectargument 0, RESULT
 	lockall
-	msgbox UseSurfPromptText, 5
-	compare RESULT, 0
+	msgbox UseSurfPromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq UseSurfScript_No
 	msgbox UsedSurfText, 4
 	dofieldeffect 9
@@ -2193,8 +2193,8 @@ Route101_EventScript_1A037F:: @ 81A037F
 Route103_EventScript_1A037F:: @ 81A037F
 	lock
 	faceplayer
-	msgbox Route101_Text_1C4449, 5
-	compare RESULT, 0
+	msgbox Route101_Text_1C4449, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route101_EventScript_1A039B
 	call Route101_EventScript_1A03B0
 	release
@@ -2442,8 +2442,8 @@ Route120_EventScript_1A0594:: @ 81A0594
 	end
 
 Route119_EventScript_1A05AE:: @ 81A05AE
-	msgbox Route119_Text_171BB6, 5
-	compare RESULT, 1
+	msgbox Route119_Text_171BB6, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route119_EventScript_1A05C3
 	release
 	end
@@ -3632,8 +3632,8 @@ EventScript_1A2CB0:
 	compare RESULT, 6
 	goto_if_eq EventScript_1A2CF1
 	bufferpartymonnick 0, RESULT
-	msgbox UnknownString_8198F34, 5
-	compare RESULT, 0
+	msgbox UnknownString_8198F34, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_1A2F3A
 	msgbox UsedCutRockSmashText, 4
 	closemessage
@@ -3663,8 +3663,8 @@ EventScript_1A2D08:
 	compare RESULT, 6
 	goto_if_eq EventScript_1A2D49
 	bufferpartymonnick 0, RESULT
-	msgbox UnknownString_81A197B, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A197B, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_1A2F3A
 	msgbox UsedCutRockSmashText, 4
 	closemessage
@@ -3694,8 +3694,8 @@ EventScript_1A2D60:
 	compare RESULT, 6
 	goto_if_eq EventScript_1A2DA1
 	bufferpartymonnick 0, RESULT
-	msgbox UnknownString_81A1A4B, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A1A4B, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_1A2F3A
 	msgbox UsedCutRockSmashText, 4
 	closemessage
@@ -3738,8 +3738,8 @@ SecretBase_RedCave1_EventScript_1A2DDE:: @ 81A2DDE
 	applymovement 255, SecretBase_RedCave1_Movement_1A2E11
 	waitmovement 0
 	setvar VAR_0x4097, 1
-	msgbox SecretBase_RedCave1_Text_198F89, 5
-	compare RESULT, 1
+	msgbox SecretBase_RedCave1_Text_198F89, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SecretBase_RedCave1_EventScript_1A2E08
 	closemessage
 	playse SE_KAIDAN
@@ -3786,18 +3786,18 @@ EventScript_1A2E45:
 	setorcopyvar VAR_SPECIAL_4, RESULT
 	lockall
 	special GetSecretBaseNearbyMapName
-	msgbox UnknownString_81A3C71, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A3C71, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_1A2F3A
-	msgbox UnknownString_81A38FB, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A38FB, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_1A2F3A
 	fadescreen 1
 	special MoveSecretBase
 	closemessage
 	fadescreen 0
-	msgbox UnknownString_81A3CC9, 5
-	compare RESULT, 0
+	msgbox UnknownString_81A3CC9, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq EventScript_1A2F3A
 	bufferpartymonnick 0, VAR_SPECIAL_4
 	buffermovename 1, MOVE_SECRET_POWER
@@ -3950,8 +3950,8 @@ SecretBase_RedCave1_EventScript_1A3032:: @ 81A3032
 	goto_if_eq SecretBase_RedCave1_EventScript_1A30A5
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A1AEA, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A1AEA, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A308F
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -3985,8 +3985,8 @@ SecretBase_RedCave1_EventScript_1A30AE:: @ 81A30AE
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3121
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A1E67, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A1E67, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A310B
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4020,8 +4020,8 @@ SecretBase_RedCave1_EventScript_1A312A:: @ 81A312A
 	goto_if_eq SecretBase_RedCave1_EventScript_1A319D
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A218F, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A218F, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3187
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4055,8 +4055,8 @@ SecretBase_RedCave1_EventScript_1A31A6:: @ 81A31A6
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3219
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A24E1, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A24E1, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3203
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4090,8 +4090,8 @@ SecretBase_RedCave1_EventScript_1A3222:: @ 81A3222
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3295
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A2830, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A2830, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A327F
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4125,8 +4125,8 @@ SecretBase_RedCave1_EventScript_1A329E:: @ 81A329E
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3311
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A1CB2, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A1CB2, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A32FB
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4160,8 +4160,8 @@ SecretBase_RedCave1_EventScript_1A331A:: @ 81A331A
 	goto_if_eq SecretBase_RedCave1_EventScript_1A338D
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A2026, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A2026, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3377
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4195,8 +4195,8 @@ SecretBase_RedCave1_EventScript_1A3396:: @ 81A3396
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3409
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A236A, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A236A, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A33F3
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4230,8 +4230,8 @@ SecretBase_RedCave1_EventScript_1A3412:: @ 81A3412
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3485
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A2663, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A2663, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A346F
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4265,8 +4265,8 @@ SecretBase_RedCave1_EventScript_1A348E:: @ 81A348E
 	goto_if_eq SecretBase_RedCave1_EventScript_1A3501
 	lock
 	faceplayer
-	msgbox SecretBase_RedCave1_Text_1A2A13, 5
-	compare RESULT, 0
+	msgbox SecretBase_RedCave1_Text_1A2A13, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SecretBase_RedCave1_EventScript_1A34EB
 	setvar RESULT, 1
 	special sub_80BCE4C
@@ -4395,10 +4395,10 @@ SlateportCity_PokemonFanClub_EventScript_1ADE4D:: @ 81ADE4D
 	compare RESULT, 1
 	goto_if_eq SlateportCity_PokemonFanClub_EventScript_1ADED6
 	copyvar VAR_SPECIAL_9, VAR_SPECIAL_6
-	msgbox SlateportCity_PokemonFanClub_Text_1A8704, 5
-	compare RESULT, 1
+	msgbox SlateportCity_PokemonFanClub_Text_1A8704, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SlateportCity_PokemonFanClub_EventScript_1ADE84
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq SlateportCity_PokemonFanClub_EventScript_1ADEB9
 	end
 
@@ -4443,18 +4443,18 @@ SlateportCity_OceanicMuseum_1F_EventScript_1ADEE0:: @ 81ADEE0
 	checkflag FLAG_OCEANIC_MUSEUM_MET_REPORTER
 	goto_if_eq SlateportCity_OceanicMuseum_1F_EventScript_1ADF25
 	setflag FLAG_OCEANIC_MUSEUM_MET_REPORTER
-	msgbox SlateportCity_OceanicMuseum_1F_Text_1A927F, 5
-	compare RESULT, 1
+	msgbox SlateportCity_OceanicMuseum_1F_Text_1A927F, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SlateportCity_OceanicMuseum_1F_EventScript_1ADF44
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq SlateportCity_OceanicMuseum_1F_EventScript_1ADF79
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_1ADF25:: @ 81ADF25
-	msgbox SlateportCity_OceanicMuseum_1F_Text_1A934C, 5
-	compare RESULT, 1
+	msgbox SlateportCity_OceanicMuseum_1F_Text_1A934C, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SlateportCity_OceanicMuseum_1F_EventScript_1ADF44
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq SlateportCity_OceanicMuseum_1F_EventScript_1ADF79
 	end
 
@@ -4499,10 +4499,10 @@ SlateportCity_PokemonFanClub_EventScript_1ADFA0:: @ 81ADFA0
 	compare RESULT, 1
 	goto_if_eq SlateportCity_PokemonFanClub_EventScript_1AE0AC
 	copyvar VAR_SPECIAL_9, VAR_SPECIAL_6
-	msgbox SlateportCity_PokemonFanClub_Text_1A82F1, 5
-	compare RESULT, 1
+	msgbox SlateportCity_PokemonFanClub_Text_1A82F1, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SlateportCity_PokemonFanClub_EventScript_1ADFE9
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq SlateportCity_PokemonFanClub_EventScript_1AE0A2
 	end
 
@@ -4576,10 +4576,10 @@ VerdanturfTown_ContestLobby_EventScript_1AE0B6:: @ 81AE0B6
 	compare RESULT, 1
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1AE17E
 	copyvar VAR_SPECIAL_9, VAR_SPECIAL_6
-	msgbox FallarborTown_ContestLobby_Text_1A6F7C, 5
-	compare RESULT, 1
+	msgbox FallarborTown_ContestLobby_Text_1A6F7C, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1AE0F8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1AE12D
 	end
 
@@ -4673,10 +4673,10 @@ BattleTower_Lobby_EventScript_1AE1FF:: @ 81AE1FF
 	compare RESULT, 1
 	goto_if_eq BattleTower_Lobby_EventScript_1AE2E3
 	copyvar VAR_SPECIAL_9, VAR_SPECIAL_6
-	msgbox BattleTower_Lobby_Text_1A776D, 5
-	compare RESULT, 1
+	msgbox BattleTower_Lobby_Text_1A776D, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq BattleTower_Lobby_EventScript_1AE241
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq BattleTower_Lobby_EventScript_1AE297
 	end
 

--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -8,6 +8,7 @@
 #include "constants/opponents.h"
 #include "constants/songs.h"
 #include "constants/species.h"
+#include "constants/weather.h"
 #include "constants/vars.h"
 	.include "asm/macros.inc"
 	.include "asm/macros/event.inc"
@@ -2090,9 +2091,9 @@ Route127_EventScript_1A02C1:: @ 81A02C1
 Route128_EventScript_1A02C1:: @ 81A02C1
 SootopolisCity_EventScript_1A02C1:: @ 81A02C1
 	.ifdef SAPPHIRE
-	setweather 13
+	setweather WEATHER_RAIN_HEAVY
 	.else
-	setweather 12
+	setweather WEATHER_DROUGHT
 	.endif
 	return
 

--- a/data/field_move_scripts.inc
+++ b/data/field_move_scripts.inc
@@ -8,8 +8,8 @@ S_CuttableTree:: @ 81B0DCC
 	setfieldeffectargument 0, RESULT
 	bufferpartymonnick 0, RESULT
 	buffermovename 1, MOVE_CUT
-	msgbox UseCutPromptText, 5
-	compare RESULT, 0
+	msgbox UseCutPromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Cut_ChoseNo
 	msgbox UsedCutRockSmashText, 4
 	closemessage
@@ -66,8 +66,8 @@ S_BreakableRock:: @ 81B0EB7
 	setfieldeffectargument 0, RESULT
 	bufferpartymonnick 0, RESULT
 	buffermovename 1, MOVE_ROCK_SMASH
-	msgbox UseRockSmashPromptText, 5
-	compare RESULT, 0
+	msgbox UseRockSmashPromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq RockSmash_ChoseNo
 	msgbox UsedCutRockSmashText, 4
 	closemessage
@@ -133,8 +133,8 @@ S_PushableBoulder:: @ 81B0FCB
 	compare RESULT, 6
 	goto_if_eq CannotUseStrength
 	setfieldeffectargument 0, RESULT
-	msgbox UseStrengthPromptText, 5
-	compare RESULT, 0
+	msgbox UseStrengthPromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Strength_ChoseNo
 	closemessage
 	dofieldeffect 40
@@ -195,8 +195,8 @@ S_UseWaterfall:: @ 81B115A
 	goto_if_eq Waterfall_NoMonKnows
 	bufferpartymonnick 0, RESULT
 	setfieldeffectargument 0, RESULT
-	msgbox UseWaterfallPromptText, 5
-	compare RESULT, 0
+	msgbox UseWaterfallPromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Waterfall_Done
 	msgbox UsedWaterfallText, 4
 	dofieldeffect 43
@@ -229,8 +229,8 @@ UseDiveScript:: @ 81B1220
 	bufferpartymonnick 0, RESULT
 	setfieldeffectargument 0, RESULT
 	setfieldeffectargument 1, 1
-	msgbox UseDivePromptText, 5
-	compare RESULT, 0
+	msgbox UseDivePromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Dive_Done
 	msgbox UsedDiveText, 4
 	dofieldeffect 44
@@ -252,8 +252,8 @@ S_UseDiveUnderwater:: @ 81B1269
 	bufferpartymonnick 0, RESULT
 	setfieldeffectargument 0, RESULT
 	setfieldeffectargument 1, 1
-	msgbox UnderwaterUseDivePromptText, 5
-	compare RESULT, 0
+	msgbox UnderwaterUseDivePromptText, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq UnderwaterDive_Done
 	msgbox UsedDiveText, 4
 	dofieldeffect 44

--- a/data/scripts/berry_tree.inc
+++ b/data/scripts/berry_tree.inc
@@ -31,10 +31,10 @@ Route102_EventScript_1A153D:: @ 81A153D
 	end
 
 Route102_EventScript_1A1558:: @ 81A1558
-	msgbox Route102_Text_1A16CD, 5
-	compare RESULT, 1
+	msgbox Route102_Text_1A16CD, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route102_EventScript_1A1577
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq Route102_EventScript_1A1593
 	end
 
@@ -101,10 +101,10 @@ Route102_EventScript_1A15F9:: @ 81A15F9
 	buffernumberstring 1, VAR_SPECIAL_6
 	lock
 	faceplayer
-	msgbox Route102_Text_1A17C0, 5
-	compare RESULT, 1
+	msgbox Route102_Text_1A17C0, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route102_EventScript_1A161D
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq Route102_EventScript_1A164B
 
 Route102_EventScript_1A161D:: @ 81A161D
@@ -148,10 +148,10 @@ Route102_EventScript_1A165F:: @ 81A165F
 	checkitem ITEM_WAILMER_PAIL, 1
 	compare RESULT, 0
 	goto_if_eq Route102_EventScript_1A168D
-	msgbox Route102_Text_1A18E6, 5
-	compare RESULT, 1
+	msgbox Route102_Text_1A18E6, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route102_EventScript_1A1693
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq Route102_EventScript_1A168D
 
 Route102_EventScript_1A168D:: @ 81A168D

--- a/data/scripts/berry_tree.inc
+++ b/data/scripts/berry_tree.inc
@@ -113,7 +113,7 @@ Route102_EventScript_1A161D:: @ 81A161D
 	goto_if_eq Route102_EventScript_1A1642
 	special FieldObjectInteractionRemoveBerryTree
 	message Route102_Text_1A17FD
-	playfanfare 387
+	playfanfare BGM_ME_KINOMI
 	waitmessage
 	waitfanfare
 	waitbuttonpress

--- a/data/scripts/cable_club.inc
+++ b/data/scripts/cable_club.inc
@@ -136,7 +136,7 @@ OldaleTown_PokemonCenter_2F_EventScript_1A3E30:: @ 81A3E30
 	waitmovement 0
 	message OldaleTown_PokemonCenter_2F_Text_1A4E50
 	waitmessage
-	playse 21
+	playse SE_PIN
 	message OldaleTown_PokemonCenter_2F_Text_1A4E79
 	waitmessage
 	applymovement 255, OldaleTown_PokemonCenter_2F_Movement_1A4358

--- a/data/scripts/cable_club.inc
+++ b/data/scripts/cable_club.inc
@@ -351,10 +351,10 @@ VerdanturfTown_PokemonCenter_2F_EventScript_1A40CC:: @ 81A40CC
 	copyvar VAR_SPECIAL_7, LAST_TALKED
 	lock
 	faceplayer
-	msgbox OldaleTown_PokemonCenter_2F_Text_1A457E, 5
-	compare RESULT, 0
+	msgbox OldaleTown_PokemonCenter_2F_Text_1A457E, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq OldaleTown_PokemonCenter_2F_EventScript_1A4319
-	compare RESULT, 1
+	compare RESULT, YES
 	goto_if_eq OldaleTown_PokemonCenter_2F_EventScript_1A40FA
 
 OldaleTown_PokemonCenter_2F_EventScript_1A40FA:: @ 81A40FA
@@ -448,10 +448,10 @@ VerdanturfTown_PokemonCenter_2F_EventScript_1A41FB:: @ 81A41FB
 	copyvar VAR_SPECIAL_7, LAST_TALKED
 	lock
 	faceplayer
-	msgbox OldaleTown_PokemonCenter_2F_Text_1A45FE, 5
-	compare RESULT, 0
+	msgbox OldaleTown_PokemonCenter_2F_Text_1A45FE, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq OldaleTown_PokemonCenter_2F_EventScript_1A4319
-	compare RESULT, 1
+	compare RESULT, YES
 	goto_if_eq OldaleTown_PokemonCenter_2F_EventScript_1A4229
 
 OldaleTown_PokemonCenter_2F_EventScript_1A4229:: @ 81A4229
@@ -790,8 +790,8 @@ RecordCorner_EventScript_1A44D6:: @ 81A44D6
 	end
 
 TradeRoom_PromptToCancelLink:: @ 81A44E5
-	msgbox TradeRoom_WillLinkBeTerminated, 5
-	compare RESULT, 1
+	msgbox TradeRoom_WillLinkBeTerminated, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq TradeRoom_TerminateLink
 	erasebox 0, 0, 29, 19
 	end

--- a/data/scripts/contest_hall.inc
+++ b/data/scripts/contest_hall.inc
@@ -32,8 +32,8 @@ FallarborTown_ContestLobby_EventScript_1A4EE1:: @ 81A4EE1
 	end
 
 FallarborTown_ContestLobby_EventScript_1A4EF6:: @ 81A4EF6
-	msgbox FallarborTown_ContestLobby_Text_1A64F4, 5
-	compare RESULT, 1
+	msgbox FallarborTown_ContestLobby_Text_1A64F4, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1A4F13
 	msgbox FallarborTown_ContestLobby_Text_1A65EA, 4
 	releaseall
@@ -153,17 +153,17 @@ FallarborTown_ContestLobby_EventScript_1A50C8:: @ 81A50C8
 	end
 
 FallarborTown_ContestLobby_EventScript_1A50D7:: @ 81A50D7
-	msgbox FallarborTown_ContestLobby_Text_1A67A3, 5
+	msgbox FallarborTown_ContestLobby_Text_1A67A3, MSGBOX_YESNO
 	switch RESULT
-	case 0, FallarborTown_ContestLobby_EventScript_1A5048
-	case 1, FallarborTown_ContestLobby_EventScript_1A513D
+	case NO, FallarborTown_ContestLobby_EventScript_1A5048
+	case YES, FallarborTown_ContestLobby_EventScript_1A513D
 	end
 
 FallarborTown_ContestLobby_EventScript_1A50FB:: @ 81A50FB
-	msgbox FallarborTown_ContestLobby_Text_1A6724, 5
+	msgbox FallarborTown_ContestLobby_Text_1A6724, MSGBOX_YESNO
 	switch RESULT
-	case 0, FallarborTown_ContestLobby_EventScript_1A5048
-	case 1, FallarborTown_ContestLobby_EventScript_1A513D
+	case NO, FallarborTown_ContestLobby_EventScript_1A5048
+	case YES, FallarborTown_ContestLobby_EventScript_1A513D
 	end
 
 FallarborTown_ContestLobby_EventScript_1A511F:: @ 81A511F

--- a/data/scripts/contest_hall.inc
+++ b/data/scripts/contest_hall.inc
@@ -345,13 +345,13 @@ LinkContestRoom1_EventScript_1A5323:: @ 81A5323
 	waitmovement 0
 	releaseall
 	addobject 13
-	playse 10
+	playse SE_DANSA
 	lockall
 	applymovement VAR_SPECIAL_B, LinkContestRoom1_Movement_1A5D9C
 	waitmovement 0
 	releaseall
 	addvar VAR_SPECIAL_6, -1
-	playse 15
+	playse SE_BOWA2
 	special ShowContestEntryMonPic
 	call LinkContestRoom1_EventScript_1A535E
 	return
@@ -371,7 +371,7 @@ LinkContestRoom1_EventScript_1A5370:: @ 81A5370
 LinkContestRoom1_EventScript_1A5377:: @ 81A5377
 	call LinkContestRoom1_EventScript_1A53B3
 	call LinkContestRoom1_EventScript_1A53CE
-	playse 223
+	playse SE_W227B
 	waitmessage
 	call LinkContestRoom1_EventScript_1A5A90
 	applymovement 1, LinkContestRoom1_Movement_1A5D9F
@@ -408,7 +408,7 @@ LinkContestRoom1_EventScript_1A53DF:: @ 81A53DF
 LinkContestRoom1_EventScript_1A53E5:: @ 81A53E5
 	applymovement 1, LinkContestRoom1_Movement_1A5DAF
 	waitmovement 0
-	playse 223
+	playse SE_W227B
 	call LinkContestRoom1_EventScript_1A5AE4
 	applymovement 9, LinkContestRoom1_Movement_1A5DB7
 	applymovement 12, LinkContestRoom1_Movement_1A5DBB
@@ -621,7 +621,7 @@ LinkContestRoom1_EventScript_1A5760:: @ 81A5760
 	compare VAR_TEMP_1, 1
 	goto_if_eq LinkContestRoom1_EventScript_1A5783
 	applymovement 6, LinkContestRoom1_Movement_1A5D8D
-	playse 21
+	playse SE_PIN
 	delay 14
 	setvar VAR_TEMP_1, 1
 	addvar VAR_TEMP_0, -1
@@ -634,7 +634,7 @@ LinkContestRoom1_EventScript_1A5784:: @ 81A5784
 	compare VAR_TEMP_2, 1
 	goto_if_eq LinkContestRoom1_EventScript_1A57A7
 	applymovement 12, LinkContestRoom1_Movement_1A5D8D
-	playse 21
+	playse SE_PIN
 	delay 14
 	setvar VAR_TEMP_2, 1
 	addvar VAR_TEMP_0, -1
@@ -647,7 +647,7 @@ LinkContestRoom1_EventScript_1A57A8:: @ 81A57A8
 	compare VAR_TEMP_3, 1
 	goto_if_eq LinkContestRoom1_EventScript_1A57CB
 	applymovement 7, LinkContestRoom1_Movement_1A5D8D
-	playse 21
+	playse SE_PIN
 	delay 14
 	setvar VAR_TEMP_3, 1
 	addvar VAR_TEMP_0, -1
@@ -660,7 +660,7 @@ LinkContestRoom1_EventScript_1A57CC:: @ 81A57CC
 	compare VAR_TEMP_4, 1
 	goto_if_eq LinkContestRoom1_EventScript_1A57EF
 	applymovement 8, LinkContestRoom1_Movement_1A5D8D
-	playse 21
+	playse SE_PIN
 	delay 14
 	setvar VAR_TEMP_4, 1
 	addvar VAR_TEMP_0, -1
@@ -673,7 +673,7 @@ LinkContestRoom1_EventScript_1A57F0:: @ 81A57F0
 	compare VAR_TEMP_5, 1
 	goto_if_eq LinkContestRoom1_EventScript_1A5813
 	applymovement 9, LinkContestRoom1_Movement_1A5D8D
-	playse 21
+	playse SE_PIN
 	delay 14
 	setvar VAR_TEMP_5, 1
 	addvar VAR_TEMP_0, -1
@@ -686,7 +686,7 @@ LinkContestRoom1_EventScript_1A5814:: @ 81A5814
 	compare VAR_TEMP_6, 1
 	goto_if_eq LinkContestRoom1_EventScript_1A5837
 	applymovement 10, LinkContestRoom1_Movement_1A5D8D
-	playse 21
+	playse SE_PIN
 	delay 14
 	setvar VAR_TEMP_6, 1
 	addvar VAR_TEMP_0, -1
@@ -699,7 +699,7 @@ LinkContestRoom1_EventScript_1A5838:: @ 81A5838
 	compare VAR_TEMP_7, 1
 	goto_if_eq LinkContestRoom1_EventScript_1A585B
 	applymovement 11, LinkContestRoom1_Movement_1A5D8D
-	playse 21
+	playse SE_PIN
 	delay 14
 	setvar VAR_TEMP_7, 1
 	addvar VAR_TEMP_0, -1
@@ -712,7 +712,7 @@ LinkContestRoom1_EventScript_1A585C:: @ 81A585C
 	compare VAR_TEMP_8, 1
 	goto_if_eq LinkContestRoom1_EventScript_1A587F
 	applymovement 15, LinkContestRoom1_Movement_1A5D8D
-	playse 21
+	playse SE_PIN
 	delay 14
 	setvar VAR_TEMP_8, 1
 	addvar VAR_TEMP_0, -1
@@ -805,7 +805,7 @@ LinkContestRoom1_EventScript_1A594A:: @ 81A594A
 	setvar VAR_TEMP_9, 1
 	showcontestresults
 	setvar VAR_TEMP_9, 0
-	playbgm 439, 0
+	playbgm BGM_CON_FAN, FALSE
 	return
 
 LinkContestRoom1_EventScript_1A5984:: @ 81A5984
@@ -890,7 +890,7 @@ LinkContestRoom1_EventScript_1A5A49:: @ 81A5A49
 	call LinkContestRoom1_EventScript_1A5A75
 	applymovement VAR_TEMP_3, LinkContestRoom1_Movement_1A5D99
 	waitmovement 0
-	playse 223
+	playse SE_W227B
 	setvar VAR_TEMP_1, 0
 	return
 
@@ -1002,7 +1002,7 @@ LinkContestRoom1_EventScript_1A5BAB:: @ 81A5BAB
 	waitmessage
 	call LinkContestRoom1_EventScript_1A5C7F
 	call LinkContestRoom1_EventScript_1A5CE5
-	playse 223
+	playse SE_W227B
 	setvar VAR_TEMP_1, 0
 	call LinkContestRoom1_EventScript_1A5A90
 	delay 30
@@ -1146,7 +1146,7 @@ LinkContestRoom1_EventScript_1A5D5B:: @ 81A5D5B
 	setflag FLAG_SYS_RIBBON_GET
 	lockall
 	msgbox LinkContestRoom1_Text_1A6D6A, 4
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	msgbox LinkContestRoom1_Text_1A6D96, 4
 	waitfanfare
 	special sub_80C4858

--- a/data/scripts/day_care.inc
+++ b/data/scripts/day_care.inc
@@ -14,11 +14,11 @@ Route117_EventScript_1B222D:: @ 81B222D
 	end
 
 Route117_EventScript_1B2262:: @ 81B2262
-	msgbox Route117_Text_1B2659, 5
-	compare RESULT, 1
+	msgbox Route117_Text_1B2659, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route117_EventScript_1B2298
-	msgbox Route117_Text_1B28C4, 5
-	compare RESULT, 1
+	msgbox Route117_Text_1B28C4, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route117_EventScript_1B2298
 	msgbox Route117_Text_1B2745, 4
 	clearflag FLAG_PENDING_DAYCARE_EGG
@@ -88,8 +88,8 @@ Route117_PokemonDayCare_EventScript_1B2327:: @ 81B2327
 	goto_if_eq Route117_PokemonDayCare_EventScript_1B242B
 	compare RESULT, 3
 	goto_if_eq Route117_PokemonDayCare_EventScript_1B2558
-	msgbox Route117_PokemonDayCare_Text_1B28F2, 5
-	compare RESULT, 1
+	msgbox Route117_PokemonDayCare_Text_1B28F2, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route117_PokemonDayCare_EventScript_1B236C
 	msgbox Route117_PokemonDayCare_Text_1B2A14, 4
 	release
@@ -127,8 +127,8 @@ Route117_PokemonDayCare_EventScript_1B23D0:: @ 81B23D0
 	end
 
 Route117_PokemonDayCare_EventScript_1B23DA:: @ 81B23DA
-	msgbox Route117_PokemonDayCare_Text_1B29AD, 5
-	compare RESULT, 1
+	msgbox Route117_PokemonDayCare_Text_1B29AD, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route117_PokemonDayCare_EventScript_1B236C
 	goto Route117_PokemonDayCare_EventScript_1B23D0
 	end
@@ -162,11 +162,11 @@ Route117_PokemonDayCare_EventScript_1B242B:: @ 81B242B
 	msgbox Route117_PokemonDayCare_Text_1B2A88, 4
 	setvar VAR_SPECIAL_4, 0
 	call Route117_PokemonDayCare_EventScript_1B241A
-	msgbox Route117_PokemonDayCare_Text_1B29AD, 5
-	compare RESULT, 1
+	msgbox Route117_PokemonDayCare_Text_1B29AD, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route117_PokemonDayCare_EventScript_1B236C
-	msgbox Route117_PokemonDayCare_Text_1B2BF6, 5
-	compare RESULT, 1
+	msgbox Route117_PokemonDayCare_Text_1B2BF6, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route117_PokemonDayCare_EventScript_1B2469
 	goto Route117_PokemonDayCare_EventScript_1B23D0
 	end
@@ -189,8 +189,8 @@ Route117_PokemonDayCare_EventScript_1B2469:: @ 81B2469
 
 Route117_PokemonDayCare_EventScript_1B24A8:: @ 81B24A8
 	special GetDaycareCost
-	msgbox Route117_PokemonDayCare_Text_1B2B49, 5
-	compare RESULT, 1
+	msgbox Route117_PokemonDayCare_Text_1B2B49, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route117_PokemonDayCare_EventScript_1B24C4
 	goto Route117_PokemonDayCare_EventScript_1B23D0
 	end
@@ -221,8 +221,8 @@ Route117_PokemonDayCare_EventScript_1B24DE:: @ 81B24DE
 	end
 
 Route117_PokemonDayCare_EventScript_1B2520:: @ 81B2520
-	msgbox Route117_PokemonDayCare_Text_1B2A4F, 5
-	compare RESULT, 1
+	msgbox Route117_PokemonDayCare_Text_1B2A4F, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route117_PokemonDayCare_EventScript_1B2469
 	goto Route117_PokemonDayCare_EventScript_1B23D0
 	end
@@ -263,8 +263,8 @@ Route117_PokemonDayCare_EventScript_1B2558:: @ 81B2558
 	call Route117_PokemonDayCare_EventScript_1B241A
 	setvar VAR_SPECIAL_4, 1
 	call Route117_PokemonDayCare_EventScript_1B241A
-	msgbox Route117_PokemonDayCare_Text_1B2BF6, 5
-	compare RESULT, 1
+	msgbox Route117_PokemonDayCare_Text_1B2BF6, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route117_PokemonDayCare_EventScript_1B2469
 	msgbox Route117_PokemonDayCare_Text_1B2A76, 4
 	release

--- a/data/scripts/day_care.inc
+++ b/data/scripts/day_care.inc
@@ -36,7 +36,7 @@ Route117_EventScript_1B2298:: @ 81B2298
 
 Route117_EventScript_1B22B2:: @ 81B22B2
 	message Route117_Text_1B27A2
-	playfanfare 367
+	playfanfare BGM_FANFA1
 	waitfanfare
 	waitmessage
 	waitbuttonpress
@@ -208,7 +208,7 @@ Route117_PokemonDayCare_EventScript_1B24DE:: @ 81B24DE
 	waitmovement 0
 	specialvar RESULT, TakePokemonFromDaycare
 	special PayMoneyFor
-	playse 95
+	playse SE_REGI
 	msgbox Route117_PokemonDayCare_Text_1B2B75, 4
 	waitse
 	playmoncry RESULT, 0

--- a/data/scripts/gabby_and_ty.inc
+++ b/data/scripts/gabby_and_ty.inc
@@ -210,7 +210,7 @@ Route111_EventScript_1AE5A2:: @ 81AE5A2
 	call_if 1, Route111_EventScript_1AE5FD
 	checkflag FLAG_TEMP_1
 	goto_if_eq Route111_EventScript_1AE73A
-	msgbox Route111_Text_1AC015, 5
+	msgbox Route111_Text_1AC015, MSGBOX_YESNO
 	goto Route111_EventScript_1AE6F3
 	end
 
@@ -270,37 +270,37 @@ Route111_Movement_1AE69D:: @ 81AE69D
 	step_end
 
 Route111_EventScript_1AE69F:: @ 81AE69F
-	msgbox Route111_Text_1AC60B, 5
+	msgbox Route111_Text_1AC60B, MSGBOX_YESNO
 	goto Route111_EventScript_1AE6F3
 	end
 
 Route111_EventScript_1AE6AD:: @ 81AE6AD
-	msgbox Route111_Text_1AC3CF, 5
+	msgbox Route111_Text_1AC3CF, MSGBOX_YESNO
 	goto Route111_EventScript_1AE6F3
 	end
 
 Route111_EventScript_1AE6BB:: @ 81AE6BB
-	msgbox Route111_Text_1AC18D, 5
+	msgbox Route111_Text_1AC18D, MSGBOX_YESNO
 	goto Route111_EventScript_1AE6F3
 	end
 
 Route111_EventScript_1AE6C9:: @ 81AE6C9
-	msgbox Route111_Text_1AC219, 5
+	msgbox Route111_Text_1AC219, MSGBOX_YESNO
 	goto Route111_EventScript_1AE6F3
 	end
 
 Route111_EventScript_1AE6D7:: @ 81AE6D7
-	msgbox Route111_Text_1AC2D6, 5
+	msgbox Route111_Text_1AC2D6, MSGBOX_YESNO
 	goto Route111_EventScript_1AE6F3
 	end
 
 Route111_EventScript_1AE6E5:: @ 81AE6E5
-	msgbox Route111_Text_1AC355, 5
+	msgbox Route111_Text_1AC355, MSGBOX_YESNO
 	goto Route111_EventScript_1AE6F3
 	end
 
 Route111_EventScript_1AE6F3:: @ 81AE6F3
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq Route111_EventScript_1AE72D
 	msgbox Route111_Text_1AC40F, 4
 	setvar VAR_SPECIAL_4, 10

--- a/data/scripts/magma_chimney.inc
+++ b/data/scripts/magma_chimney.inc
@@ -37,7 +37,7 @@ MtChimney_EventScript_1B2CCB:: @ 81B2CCB
 	.endif
 	applymovement 2, MtChimney_Movement_1A0839
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 2, MtChimney_Movement_1A0833
 	waitmovement 0
 	applymovement 2, MtChimney_Movement_1A0835

--- a/data/scripts/maps/AbandonedShip_Corridors_B1F.inc
+++ b/data/scripts/maps/AbandonedShip_Corridors_B1F.inc
@@ -34,7 +34,7 @@ AbandonedShip_Corridors_B1F_EventScript_15E9D3:: @ 815E9D3
 	compare RESULT, 0
 	goto_if_eq AbandonedShip_Corridors_B1F_EventScript_15EA0A
 	msgbox AbandonedShip_Corridors_B1F_Text_198692, 4
-	playse 21
+	playse SE_PIN
 	takeitem ITEM_STORAGE_KEY, 1
 	setflag FLAG_USED_STORAGE_KEY
 	call AbandonedShip_Corridors_B1F_EventScript_15E9C0

--- a/data/scripts/maps/AbandonedShip_HiddenFloorCorridors.inc
+++ b/data/scripts/maps/AbandonedShip_HiddenFloorCorridors.inc
@@ -66,7 +66,7 @@ AbandonedShip_HiddenFloorCorridors_EventScript_15EBF3:: @ 815EBF3
 	compare RESULT, 0
 	goto_if_eq AbandonedShip_HiddenFloorCorridors_EventScript_15ECCF
 	msgbox AbandonedShip_HiddenFloorCorridors_Text_198E90, 4
-	playse 21
+	playse SE_PIN
 	takeitem ITEM_ROOM_1_KEY, 1
 	setflag FLAG_USED_ROOM_1_KEY
 	call AbandonedShip_HiddenFloorCorridors_EventScript_15EBA3
@@ -82,7 +82,7 @@ AbandonedShip_HiddenFloorCorridors_EventScript_15EC2A:: @ 815EC2A
 	compare RESULT, 0
 	goto_if_eq AbandonedShip_HiddenFloorCorridors_EventScript_15ECD9
 	msgbox AbandonedShip_HiddenFloorCorridors_Text_198E90, 4
-	playse 21
+	playse SE_PIN
 	takeitem ITEM_ROOM_2_KEY, 1
 	setflag FLAG_USED_ROOM_2_KEY
 	call AbandonedShip_HiddenFloorCorridors_EventScript_15EBAD
@@ -98,7 +98,7 @@ AbandonedShip_HiddenFloorCorridors_EventScript_15EC61:: @ 815EC61
 	compare RESULT, 0
 	goto_if_eq AbandonedShip_HiddenFloorCorridors_EventScript_15ECE3
 	msgbox AbandonedShip_HiddenFloorCorridors_Text_198E90, 4
-	playse 21
+	playse SE_PIN
 	takeitem ITEM_ROOM_4_KEY, 1
 	setflag FLAG_USED_ROOM_4_KEY
 	call AbandonedShip_HiddenFloorCorridors_EventScript_15EBB7
@@ -114,7 +114,7 @@ AbandonedShip_HiddenFloorCorridors_EventScript_15EC98:: @ 815EC98
 	compare RESULT, 0
 	goto_if_eq AbandonedShip_HiddenFloorCorridors_EventScript_15ECED
 	msgbox AbandonedShip_HiddenFloorCorridors_Text_198E90, 4
-	playse 21
+	playse SE_PIN
 	takeitem ITEM_ROOM_6_KEY, 1
 	setflag FLAG_USED_ROOM_6_KEY
 	call AbandonedShip_HiddenFloorCorridors_EventScript_15EBC1

--- a/data/scripts/maps/AquaHideout_B2F.inc
+++ b/data/scripts/maps/AquaHideout_B2F.inc
@@ -10,7 +10,7 @@ AquaHideout_B2F_EventScript_15D8BD:: @ 815D8BD
 MagmaHideout_B2F_EventScript_15D8BD:: @ 815D8BD
 	lockall
 	setvar VAR_SPECIAL_8, 1
-	playse 21
+	playse SE_PIN
 	applymovement VAR_SPECIAL_8, AquaHideout_B2F_Movement_1A0833
 	waitmovement 0
 	.ifdef SAPPHIRE

--- a/data/scripts/maps/BattleTower_BattleRoom.inc
+++ b/data/scripts/maps/BattleTower_BattleRoom.inc
@@ -59,24 +59,24 @@ BattleTower_BattleRoom_EventScript_160961:: @ 8160961
 	special ScrSpecial_HealPlayerParty
 
 BattleTower_BattleRoom_EventScript_1609B2:: @ 81609B2
-	msgbox BattleTower_BattleRoom_Text_19AD09, 5
+	msgbox BattleTower_BattleRoom_Text_19AD09, MSGBOX_YESNO
 	switch RESULT
-	case 0, BattleTower_BattleRoom_EventScript_1609E0
-	case 1, BattleTower_BattleRoom_EventScript_160A3C
+	case NO, BattleTower_BattleRoom_EventScript_1609E0
+	case YES, BattleTower_BattleRoom_EventScript_160A3C
 	case 127, BattleTower_BattleRoom_EventScript_1609E0
 
 BattleTower_BattleRoom_EventScript_1609E0:: @ 81609E0
-	msgbox BattleTower_BattleRoom_Text_19AD3C, 5
+	msgbox BattleTower_BattleRoom_Text_19AD3C, MSGBOX_YESNO
 	switch RESULT
-	case 0, BattleTower_BattleRoom_EventScript_160A0E
-	case 1, BattleTower_BattleRoom_EventScript_160A94
+	case NO, BattleTower_BattleRoom_EventScript_160A0E
+	case YES, BattleTower_BattleRoom_EventScript_160A94
 	case 127, BattleTower_BattleRoom_EventScript_160A0E
 
 BattleTower_BattleRoom_EventScript_160A0E:: @ 8160A0E
-	msgbox BattleTower_BattleRoom_Text_19AD66, 5
+	msgbox BattleTower_BattleRoom_Text_19AD66, MSGBOX_YESNO
 	switch RESULT
-	case 0, BattleTower_BattleRoom_EventScript_1609B2
-	case 1, BattleTower_BattleRoom_EventScript_160AB1
+	case NO, BattleTower_BattleRoom_EventScript_1609B2
+	case YES, BattleTower_BattleRoom_EventScript_160AB1
 	case 127, BattleTower_BattleRoom_EventScript_1609B2
 
 BattleTower_BattleRoom_EventScript_160A3C:: @ 8160A3C

--- a/data/scripts/maps/BattleTower_BattleRoom.inc
+++ b/data/scripts/maps/BattleTower_BattleRoom.inc
@@ -54,7 +54,7 @@ BattleTower_BattleRoom_EventScript_160961:: @ 8160961
 	special LoadPlayerParty
 	special SavePlayerParty
 	special SetBattleTowerParty
-	playfanfare 368
+	playfanfare BGM_ME_ASA
 	waitfanfare
 	special ScrSpecial_HealPlayerParty
 
@@ -110,7 +110,7 @@ BattleTower_BattleRoom_EventScript_160A94:: @ 8160A94
 	message BattleTower_BattleRoom_Text_1C6CE1
 	delay 60
 	waitmessage
-	playse 55
+	playse SE_SAVE
 	waitse
 	msgbox BattleTower_BattleRoom_Text_1C6D05, 4
 

--- a/data/scripts/maps/BattleTower_Lobby.inc
+++ b/data/scripts/maps/BattleTower_Lobby.inc
@@ -221,10 +221,10 @@ BattleTower_Lobby_EventScript_1604FA:: @ 81604FA
 	waitstate
 	compare RESULT, 0
 	goto_if_eq BattleTower_Lobby_EventScript_16064F
-	msgbox BattleTower_Lobby_Text_199FDA, 5
+	msgbox BattleTower_Lobby_Text_199FDA, MSGBOX_YESNO
 	switch RESULT
-	case 0, BattleTower_Lobby_EventScript_16064F
-	case 1, BattleTower_Lobby_EventScript_160587
+	case NO, BattleTower_Lobby_EventScript_16064F
+	case YES, BattleTower_Lobby_EventScript_160587
 	case 127, BattleTower_Lobby_EventScript_16064F
 
 BattleTower_Lobby_EventScript_160587:: @ 8160587
@@ -334,10 +334,10 @@ BattleTower_Lobby_Movement_16069A:: @ 816069A
 BattleTower_Lobby_EventScript_1606A5:: @ 81606A5
 	lock
 	faceplayer
-	msgbox BattleTower_Lobby_Text_19A747, 5
+	msgbox BattleTower_Lobby_Text_19A747, MSGBOX_YESNO
 	switch RESULT
-	case 1, BattleTower_Lobby_EventScript_1606CC
-	case 0, BattleTower_Lobby_EventScript_1606F7
+	case YES, BattleTower_Lobby_EventScript_1606CC
+	case NO, BattleTower_Lobby_EventScript_1606F7
 	release
 	end
 

--- a/data/scripts/maps/BattleTower_Lobby.inc
+++ b/data/scripts/maps/BattleTower_Lobby.inc
@@ -84,7 +84,7 @@ BattleTower_Lobby_EventScript_160342:: @ 8160342
 	goto_if_eq BattleTower_Lobby_EventScript_16037D
 	message BattleTower_Lobby_Text_19A6BE
 	waitmessage
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	waitfanfare
 	msgbox BattleTower_Lobby_Text_19A719, 4
 
@@ -100,7 +100,7 @@ BattleTower_Lobby_EventScript_16037D:: @ 816037D
 	special DetermineBattleTowerPrize
 	setvar VAR_SPECIAL_4, 3
 	special SaveBattleTowerProgress
-	playse 55
+	playse SE_SAVE
 	waitse
 
 BattleTower_Lobby_EventScript_1603AD:: @ 81603AD
@@ -114,7 +114,7 @@ BattleTower_Lobby_EventScript_1603AD:: @ 81603AD
 	case 0, BattleTower_Lobby_EventScript_160408
 	message BattleTower_Lobby_Text_19A506
 	waitmessage
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	waitfanfare
 	setvar VAR_SPECIAL_4, 9
 	special BattleTowerUtil
@@ -148,7 +148,7 @@ BattleTower_Lobby_EventScript_160419:: @ 8160419
 	special SetBattleTowerProperty
 	setvar VAR_SPECIAL_4, 0
 	special SaveBattleTowerProgress
-	playse 55
+	playse SE_SAVE
 	waitse
 	msgbox BattleTower_Lobby_Text_199FA9, 4
 	closemessage
@@ -166,7 +166,7 @@ BattleTower_Lobby_EventScript_16044B:: @ 816044B
 	waitmessage
 	setvar VAR_SPECIAL_4, 1
 	special SaveBattleTowerProgress
-	playse 55
+	playse SE_SAVE
 	waitse
 	setvar VAR_SPECIAL_4, 8
 	setvar VAR_SPECIAL_5, 0

--- a/data/scripts/maps/BattleTower_Outside.inc
+++ b/data/scripts/maps/BattleTower_Outside.inc
@@ -35,8 +35,8 @@ BattleTower_Outside_EventScript_1601C6:: @ 81601C6
 	end
 
 BattleTower_Outside_EventScript_1601D0:: @ 81601D0
-	msgbox BattleTower_Outside_Text_199DF2, 5
-	compare RESULT, 0
+	msgbox BattleTower_Outside_Text_199DF2, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq BattleTower_Outside_EventScript_160226
 	msgbox BattleTower_Outside_Text_199E4B, 4
 	call BattleTower_Outside_EventScript_160232
@@ -46,8 +46,8 @@ BattleTower_Outside_EventScript_1601D0:: @ 81601D0
 	end
 
 BattleTower_Outside_EventScript_1601FB:: @ 81601FB
-	msgbox BattleTower_Outside_Text_199E0E, 5
-	compare RESULT, 0
+	msgbox BattleTower_Outside_Text_199E0E, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq BattleTower_Outside_EventScript_160226
 	msgbox BattleTower_Outside_Text_199E4B, 4
 	call BattleTower_Outside_EventScript_160232

--- a/data/scripts/maps/CaveOfOrigin_B4F.inc
+++ b/data/scripts/maps/CaveOfOrigin_B4F.inc
@@ -33,7 +33,7 @@ CaveOfOrigin_B4F_EventScript_15DDD7:: @ 815DDD7
 	msgbox CaveOfOrigin_B4F_Text_1B4FE4, 4
 	.endif
 	closemessage
-	setweather 0
+	setweather WEATHER_NONE
 	doweather
 	special WaitWeather
 	waitstate

--- a/data/scripts/maps/CaveOfOrigin_B4F.inc
+++ b/data/scripts/maps/CaveOfOrigin_B4F.inc
@@ -37,7 +37,7 @@ CaveOfOrigin_B4F_EventScript_15DDD7:: @ 815DDD7
 	doweather
 	special WaitWeather
 	waitstate
-	playse 209
+	playse SE_W197
 	setfieldeffectargument 0, 9
 	setfieldeffectargument 1, 13
 	setfieldeffectargument 2, 0
@@ -48,7 +48,7 @@ CaveOfOrigin_B4F_EventScript_15DDD7:: @ 815DDD7
 	.else
 	setvar RESULT, 2
 	.endif
-	playse 107
+	playse SE_TAMA
 	special sub_80818A4
 	waitstate
 	special sub_80818FC

--- a/data/scripts/maps/DewfordTown.inc
+++ b/data/scripts/maps/DewfordTown.inc
@@ -42,8 +42,8 @@ DewfordTown_EventScript_14E06B:: @ 814E06B
 	end
 
 DewfordTown_EventScript_14E076:: @ 814E076
-	msgbox DewfordTown_Text_16B3BC, 5
-	compare RESULT, 1
+	msgbox DewfordTown_Text_16B3BC, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq DewfordTown_EventScript_14E093
 	msgbox DewfordTown_Text_16B471, 4
 	release
@@ -76,10 +76,10 @@ DewfordTown_EventScript_14E0C6:: @ 814E0C6
 	faceplayer
 	checkflag FLAG_RECEIVED_OLD_ROD
 	goto_if_eq DewfordTown_EventScript_14E11B
-	msgbox DewfordTown_Text_16B665, 5
-	compare RESULT, 1
+	msgbox DewfordTown_Text_16B665, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq DewfordTown_EventScript_14E0F0
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq DewfordTown_EventScript_14E111
 	end
 
@@ -598,10 +598,10 @@ DewfordTown_EventScript_14E413:: @ 814E413
 	lock
 	faceplayer
 	call DewfordTown_EventScript_1A0102
-	msgbox DewfordTown_Text_16B9CE, 5
-	compare RESULT, 1
+	msgbox DewfordTown_Text_16B9CE, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq DewfordTown_EventScript_14E439
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq DewfordTown_EventScript_14E443
 	end
 

--- a/data/scripts/maps/DewfordTown_Gym.inc
+++ b/data/scripts/maps/DewfordTown_Gym.inc
@@ -56,25 +56,25 @@ DewfordTown_Gym_EventScript_1530F5:: @ 81530F5
 	return
 
 DewfordTown_Gym_EventScript_1530F6:: @ 81530F6
-	playse 35
+	playse SE_MU_PACHI
 	animateflash 3
 	call DewfordTown_Gym_EventScript_153071
 	return
 
 DewfordTown_Gym_EventScript_153101:: @ 8153101
-	playse 35
+	playse SE_MU_PACHI
 	animateflash 2
 	call DewfordTown_Gym_EventScript_153071
 	return
 
 DewfordTown_Gym_EventScript_15310C:: @ 815310C
-	playse 35
+	playse SE_MU_PACHI
 	animateflash 1
 	call DewfordTown_Gym_EventScript_153071
 	return
 
 DewfordTown_Gym_EventScript_153117:: @ 8153117
-	playse 35
+	playse SE_MU_PACHI
 	animateflash 0
 	call DewfordTown_Gym_EventScript_153071
 	return

--- a/data/scripts/maps/DewfordTown_Hall.inc
+++ b/data/scripts/maps/DewfordTown_Hall.inc
@@ -30,10 +30,10 @@ DewfordTown_Hall_EventScript_1532CD:: @ 81532CD
 	faceplayer
 	call DewfordTown_Hall_EventScript_1A0102
 	special BufferRandomHobbyOrLifestyleString
-	msgbox DewfordTown_Hall_Text_1755F9, 5
-	compare RESULT, 1
+	msgbox DewfordTown_Hall_Text_1755F9, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq DewfordTown_Hall_EventScript_1532F6
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq DewfordTown_Hall_EventScript_153300
 	end
 

--- a/data/scripts/maps/EverGrandeCity_ChampionsRoom.inc
+++ b/data/scripts/maps/EverGrandeCity_ChampionsRoom.inc
@@ -38,20 +38,20 @@ EverGrandeCity_ChampionsRoom_Movement_15B802:: @ 815B802
 	step_end
 
 EverGrandeCity_ChampionsRoom_EventScript_15B805:: @ 815B805
-	playbgm 454, 0
+	playbgm BGM_DAIGO, FALSE
 	msgbox EverGrandeCity_ChampionsRoom_Text_190F9C, 4
 	trainerbattle 3, OPPONENT_STEVEN, 0, EverGrandeCity_ChampionsRoom_Text_1910A0
 	goto EverGrandeCity_ChampionsRoom_EventScript_15B821
 	end
 
 EverGrandeCity_ChampionsRoom_EventScript_15B821:: @ 815B821
-	playse 8
+	playse SE_DOOR
 	setmetatile 6, 1, 838, 0
 	setmetatile 6, 2, 839, 0
 	special DrawWholeMapView
 	msgbox EverGrandeCity_ChampionsRoom_Text_1910FE, 4
 	closemessage
-	playse 8
+	playse SE_DOOR
 	checkplayergender
 	compare RESULT, 0
 	call_if 1, EverGrandeCity_ChampionsRoom_EventScript_15B87C
@@ -67,17 +67,17 @@ EverGrandeCity_ChampionsRoom_EventScript_15B821:: @ 815B821
 	end
 
 EverGrandeCity_ChampionsRoom_EventScript_15B87C:: @ 815B87C
-	playbgm 415, 0
+	playbgm BGM_GIRL_SUP, FALSE
 	return
 
 EverGrandeCity_ChampionsRoom_EventScript_15B881:: @ 815B881
-	playbgm 421, 0
+	playbgm BGM_BOY_SUP, FALSE
 	return
 
 EverGrandeCity_ChampionsRoom_EventScript_15B886:: @ 815B886
 	msgbox EverGrandeCity_ChampionsRoom_Text_191225, 4
 	delay 40
-	playse 21
+	playse SE_PIN
 	applymovement 2, EverGrandeCity_ChampionsRoom_Movement_1A0833
 	waitmovement 0
 	applymovement 2, EverGrandeCity_ChampionsRoom_Movement_1A0835
@@ -90,7 +90,7 @@ EverGrandeCity_ChampionsRoom_EventScript_15B886:: @ 815B886
 EverGrandeCity_ChampionsRoom_EventScript_15B8BB:: @ 815B8BB
 	msgbox EverGrandeCity_ChampionsRoom_Text_1912B3, 4
 	delay 40
-	playse 21
+	playse SE_PIN
 	applymovement 2, EverGrandeCity_ChampionsRoom_Movement_1A0833
 	waitmovement 0
 	applymovement 2, EverGrandeCity_ChampionsRoom_Movement_1A0835

--- a/data/scripts/maps/EverGrandeCity_DrakesRoom.inc
+++ b/data/scripts/maps/EverGrandeCity_DrakesRoom.inc
@@ -43,7 +43,7 @@ EverGrandeCity_DrakesRoom_EventScript_15B764:: @ 815B764
 	faceplayer
 	checkflag FLAG_DEFEATED_ELITE_4_DRAKE
 	goto_if_eq EverGrandeCity_DrakesRoom_EventScript_15B78B
-	playbgm 450, 0
+	playbgm BGM_SITENNOU, FALSE
 	msgbox EverGrandeCity_DrakesRoom_Text_190CEB, 4
 	trainerbattle 3, OPPONENT_DRAKE, 0, EverGrandeCity_DrakesRoom_Text_190E42
 	goto EverGrandeCity_DrakesRoom_EventScript_15B795

--- a/data/scripts/maps/EverGrandeCity_GlaciasRoom.inc
+++ b/data/scripts/maps/EverGrandeCity_GlaciasRoom.inc
@@ -43,7 +43,7 @@ EverGrandeCity_GlaciasRoom_EventScript_15B6CA:: @ 815B6CA
 	faceplayer
 	checkflag FLAG_DEFEATED_ELITE_4_GLACIA
 	goto_if_eq EverGrandeCity_GlaciasRoom_EventScript_15B6F1
-	playbgm 450, 0
+	playbgm BGM_SITENNOU, FALSE
 	msgbox EverGrandeCity_GlaciasRoom_Text_190AF9, 4
 	trainerbattle 3, OPPONENT_GLACIA, 0, EverGrandeCity_GlaciasRoom_Text_190C01
 	goto EverGrandeCity_GlaciasRoom_EventScript_15B6FB

--- a/data/scripts/maps/EverGrandeCity_PhoebesRoom.inc
+++ b/data/scripts/maps/EverGrandeCity_PhoebesRoom.inc
@@ -43,7 +43,7 @@ EverGrandeCity_PhoebesRoom_EventScript_15B630:: @ 815B630
 	faceplayer
 	checkflag FLAG_DEFEATED_ELITE_4_PHOEBE
 	goto_if_eq EverGrandeCity_PhoebesRoom_EventScript_15B657
-	playbgm 450, 0
+	playbgm BGM_SITENNOU, FALSE
 	msgbox EverGrandeCity_PhoebesRoom_Text_1908F5, 4
 	trainerbattle 3, OPPONENT_PHOEBE, 0, EverGrandeCity_PhoebesRoom_Text_190A0C
 	goto EverGrandeCity_PhoebesRoom_EventScript_15B661

--- a/data/scripts/maps/EverGrandeCity_PokemonLeague.inc
+++ b/data/scripts/maps/EverGrandeCity_PokemonLeague.inc
@@ -64,7 +64,7 @@ EverGrandeCity_PokemonLeague_EventScript_15BAD2:: @ 815BAD2
 	applymovement 4, EverGrandeCity_PokemonLeague_Movement_15BB81
 	waitmovement 0
 	delay 10
-	playfanfare 369
+	playfanfare BGM_ME_BACHI
 	message EverGrandeCity_PokemonLeague_Text_191804
 	waitmessage
 	waitfanfare
@@ -86,7 +86,7 @@ EverGrandeCity_PokemonLeague_EventScript_15BB3F:: @ 815BB3F
 	return
 
 EverGrandeCity_PokemonLeague_EventScript_15BB4A:: @ 815BB4A
-	playse 32
+	playse SE_HAZURE
 	msgbox EverGrandeCity_PokemonLeague_Text_19179C, 4
 	releaseall
 	end

--- a/data/scripts/maps/EverGrandeCity_SidneysRoom.inc
+++ b/data/scripts/maps/EverGrandeCity_SidneysRoom.inc
@@ -44,7 +44,7 @@ EverGrandeCity_SidneysRoom_EventScript_15B596:: @ 815B596
 	faceplayer
 	checkflag FLAG_DEFEATED_ELITE_4_SYDNEY
 	goto_if_eq EverGrandeCity_SidneysRoom_EventScript_15B5BD
-	playbgm 450, 0
+	playbgm BGM_SITENNOU, FALSE
 	msgbox EverGrandeCity_SidneysRoom_Text_190728, 4
 	trainerbattle 3, OPPONENT_SIDNEY, 0, EverGrandeCity_SidneysRoom_Text_190823
 	goto EverGrandeCity_SidneysRoom_EventScript_15B5C7

--- a/data/scripts/maps/FallarborTown_ContestLobby.inc
+++ b/data/scripts/maps/FallarborTown_ContestLobby.inc
@@ -22,13 +22,13 @@ FallarborTown_ContestLobby_EventScript_1539F8:: @ 81539F8
 	lockall
 	applymovement 1, FallarborTown_ContestLobby_Movement_153A7C
 	waitmovement 0
-	playse 71
+	playse SE_HASHI
 	setmetatile 4, 2, 545, 1
 	setmetatile 4, 3, 609, 1
 	special DrawWholeMapView
 	applymovement 1, FallarborTown_ContestLobby_Movement_153A7F
 	waitmovement 0
-	playse 71
+	playse SE_HASHI
 	setmetatile 4, 2, 721, 1
 	setmetatile 4, 3, 729, 1
 	special DrawWholeMapView

--- a/data/scripts/maps/FallarborTown_House1.inc
+++ b/data/scripts/maps/FallarborTown_House1.inc
@@ -22,7 +22,7 @@ FallarborTown_House1_EventScript_153BDA:: @ 8153BDA
 	call_if 0, FallarborTown_House1_EventScript_153C2D
 	checkflag FLAG_TEMP_2
 	call_if 1, FallarborTown_House1_EventScript_153C3E
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq FallarborTown_House1_EventScript_153C47
 	msgbox FallarborTown_House1_Text_1778C4, 4
 	giveitem_std ITEM_TM27
@@ -37,11 +37,11 @@ FallarborTown_House1_EventScript_153BDA:: @ 8153BDA
 
 FallarborTown_House1_EventScript_153C2D:: @ 8153C2D
 	msgbox FallarborTown_House1_Text_177755, 4
-	msgbox FallarborTown_House1_Text_17780E, 5
+	msgbox FallarborTown_House1_Text_17780E, MSGBOX_YESNO
 	return
 
 FallarborTown_House1_EventScript_153C3E:: @ 8153C3E
-	msgbox FallarborTown_House1_Text_1779B8, 5
+	msgbox FallarborTown_House1_Text_1779B8, MSGBOX_YESNO
 	return
 
 FallarborTown_House1_EventScript_153C47:: @ 8153C47

--- a/data/scripts/maps/FallarborTown_House2.inc
+++ b/data/scripts/maps/FallarborTown_House2.inc
@@ -16,9 +16,9 @@ FallarborTown_House2_EventScript_153CB6:: @ 8153CB6
 	checkitem ITEM_HEART_SCALE, 1
 	compare RESULT, 0
 	goto_if_eq FallarborTown_House2_EventScript_153D60
-	msgbox FallarborTown_House2_Text_177BDB, 5
+	msgbox FallarborTown_House2_Text_177BDB, MSGBOX_YESNO
 	switch RESULT
-	case 0, FallarborTown_House2_EventScript_153D60
+	case NO, FallarborTown_House2_EventScript_153D60
 	goto FallarborTown_House2_EventScript_153CE4
 	end
 

--- a/data/scripts/maps/FallarborTown_PokemonCenter_1F.inc
+++ b/data/scripts/maps/FallarborTown_PokemonCenter_1F.inc
@@ -46,7 +46,7 @@ FallarborTown_PokemonCenter_1F_EventScript_153B59:: @ 8153B59
 	end
 
 FallarborTown_PokemonCenter_1F_EventScript_153B69:: @ 8153B69
-	playse 18
+	playse SE_JIDO_DOA
 	removeobject 4
 	clearflag FLAG_HIDE_LANETTE
 	release

--- a/data/scripts/maps/FortreeCity.inc
+++ b/data/scripts/maps/FortreeCity.inc
@@ -64,8 +64,8 @@ FortreeCity_EventScript_14C9B3:: @ 814C9B3
 	end
 
 FortreeCity_EventScript_14C9CF:: @ 814C9CF
-	msgbox FortreeCity_Text_16788B, 5
-	compare RESULT, 1
+	msgbox FortreeCity_Text_16788B, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq FortreeCity_EventScript_14C9E4
 	release
 	end

--- a/data/scripts/maps/FortreeCity_House1.inc
+++ b/data/scripts/maps/FortreeCity_House1.inc
@@ -10,8 +10,8 @@ FortreeCity_House1_EventScript_157E13:: @ 8157E13
 	copyvar VAR_SPECIAL_4, VAR_SPECIAL_8
 	specialvar RESULT, GetInGameTradeSpeciesInfo
 	copyvar VAR_SPECIAL_9, RESULT
-	msgbox FortreeCity_House1_Text_18568C, 5
-	compare RESULT, 0
+	msgbox FortreeCity_House1_Text_18568C, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq FortreeCity_House1_EventScript_157E95
 	special SelectMonForNPCTrade
 	waitstate

--- a/data/scripts/maps/GraniteCave_StevensRoom.inc
+++ b/data/scripts/maps/GraniteCave_StevensRoom.inc
@@ -22,7 +22,7 @@ GraniteCave_StevensRoom_EventScript_15CBFA:: @ 815CBFA
 	call_if 1, GraniteCave_StevensRoom_EventScript_15CC6D
 	compare FACING, 4
 	call_if 1, GraniteCave_StevensRoom_EventScript_15CC6D
-	playse 9
+	playse SE_KAIDAN
 	removeobject 1
 	release
 	end

--- a/data/scripts/maps/JaggedPass.inc
+++ b/data/scripts/maps/JaggedPass.inc
@@ -13,7 +13,7 @@ JaggedPass_MapScript1_15D274:: @ 815D274
 	end
 
 JaggedPass_EventScript_15D280:: @ 815D280
-	setweather 7
+	setweather WEATHER_ASH
 	doweather
 	return
 

--- a/data/scripts/maps/LavaridgeTown.inc
+++ b/data/scripts/maps/LavaridgeTown.inc
@@ -286,7 +286,7 @@ LavaridgeTown_EventScript_14E75A:: @ 814E75A
 	message LavaridgeTown_Text_16C2EA
 	waitfanfare
 	waitmessage
-	giveegg 360
+	giveegg SPECIES_WYNAUT
 	release
 	end
 

--- a/data/scripts/maps/LavaridgeTown.inc
+++ b/data/scripts/maps/LavaridgeTown.inc
@@ -58,11 +58,11 @@ LavaridgeTown_EventScript_14E4ED:: @ 814E4ED
 	end
 
 LavaridgeTown_EventScript_14E56B:: @ 814E56B
-	playbgm 415, 1
+	playbgm BGM_GIRL_SUP, TRUE
 	return
 
 LavaridgeTown_EventScript_14E570:: @ 814E570
-	playbgm 421, 1
+	playbgm BGM_BOY_SUP, TRUE
 	return
 
 LavaridgeTown_EventScript_14E575:: @ 814E575
@@ -282,7 +282,7 @@ LavaridgeTown_EventScript_14E75A:: @ 814E75A
 	goto_if_eq LavaridgeTown_EventScript_14E7A8
 	msgbox LavaridgeTown_Text_16C2B6, 4
 	setflag FLAG_RECEIVED_LAVARIDGE_EGG
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	message LavaridgeTown_Text_16C2EA
 	waitfanfare
 	waitmessage

--- a/data/scripts/maps/LavaridgeTown.inc
+++ b/data/scripts/maps/LavaridgeTown.inc
@@ -274,8 +274,8 @@ LavaridgeTown_EventScript_14E75A:: @ 814E75A
 	faceplayer
 	checkflag FLAG_RECEIVED_LAVARIDGE_EGG
 	goto_if_eq LavaridgeTown_EventScript_14E79E
-	msgbox LavaridgeTown_Text_16C174, 5
-	compare RESULT, 0
+	msgbox LavaridgeTown_Text_16C174, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq LavaridgeTown_EventScript_14E7B2
 	getpartysize
 	compare RESULT, 6

--- a/data/scripts/maps/LilycoveCity.inc
+++ b/data/scripts/maps/LilycoveCity.inc
@@ -260,7 +260,7 @@ LilycoveCity_EventScript_14CD60:: @ 814CD60
 	call_if 1, LilycoveCity_EventScript_14CDB0
 	checkflag FLAG_DECLINED_RIVAL_BATTLE_LILYCOVE
 	call_if 0, LilycoveCity_EventScript_14CDB9
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq LilycoveCity_EventScript_14CDC2
 	msgbox LilycoveCity_Text_167B94, 4
 	switch VAR_STARTER_MON
@@ -270,11 +270,11 @@ LilycoveCity_EventScript_14CD60:: @ 814CD60
 	end
 
 LilycoveCity_EventScript_14CDB0:: @ 814CDB0
-	msgbox LilycoveCity_Text_167B55, 5
+	msgbox LilycoveCity_Text_167B55, MSGBOX_YESNO
 	return
 
 LilycoveCity_EventScript_14CDB9:: @ 814CDB9
-	msgbox LilycoveCity_Text_1679BF, 5
+	msgbox LilycoveCity_Text_1679BF, MSGBOX_YESNO
 	return
 
 LilycoveCity_EventScript_14CDC2:: @ 814CDC2
@@ -291,7 +291,7 @@ LilycoveCity_EventScript_14CDD3:: @ 814CDD3
 	call_if 1, LilycoveCity_EventScript_14CE23
 	checkflag FLAG_DECLINED_RIVAL_BATTLE_LILYCOVE
 	call_if 0, LilycoveCity_EventScript_14CE2C
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq LilycoveCity_EventScript_14CE35
 	msgbox LilycoveCity_Text_1680A9, 4
 	switch VAR_STARTER_MON
@@ -301,11 +301,11 @@ LilycoveCity_EventScript_14CDD3:: @ 814CDD3
 	end
 
 LilycoveCity_EventScript_14CE23:: @ 814CE23
-	msgbox LilycoveCity_Text_168067, 5
+	msgbox LilycoveCity_Text_168067, MSGBOX_YESNO
 	return
 
 LilycoveCity_EventScript_14CE2C:: @ 814CE2C
-	msgbox LilycoveCity_Text_167F75, 5
+	msgbox LilycoveCity_Text_167F75, MSGBOX_YESNO
 	return
 
 LilycoveCity_EventScript_14CE35:: @ 814CE35

--- a/data/scripts/maps/LilycoveCity.inc
+++ b/data/scripts/maps/LilycoveCity.inc
@@ -255,7 +255,7 @@ LilycoveCity_EventScript_14CD46:: @ 814CD46
 	end
 
 LilycoveCity_EventScript_14CD60:: @ 814CD60
-	playbgm 415, 1
+	playbgm BGM_GIRL_SUP, TRUE
 	checkflag FLAG_DECLINED_RIVAL_BATTLE_LILYCOVE
 	call_if 1, LilycoveCity_EventScript_14CDB0
 	checkflag FLAG_DECLINED_RIVAL_BATTLE_LILYCOVE
@@ -286,7 +286,7 @@ LilycoveCity_EventScript_14CDC2:: @ 814CDC2
 	end
 
 LilycoveCity_EventScript_14CDD3:: @ 814CDD3
-	playbgm 421, 1
+	playbgm BGM_BOY_SUP, TRUE
 	checkflag FLAG_DECLINED_RIVAL_BATTLE_LILYCOVE
 	call_if 1, LilycoveCity_EventScript_14CE23
 	checkflag FLAG_DECLINED_RIVAL_BATTLE_LILYCOVE

--- a/data/scripts/maps/LilycoveCity_ContestLobby.inc
+++ b/data/scripts/maps/LilycoveCity_ContestLobby.inc
@@ -475,7 +475,7 @@ LilycoveCity_ContestLobby_EventScript_158DD1:: @ 8158DD1
 	buffernumberstring 1, 32772
 	messageautoscroll LilycoveCity_ContestLobby_Text_188845
 	waitmessage
-	addvar VAR_SPECIAL_4, 65535
+	addvar VAR_SPECIAL_4, -1
 	goto LilycoveCity_ContestLobby_EventScript_158DEE
 	end
 

--- a/data/scripts/maps/LilycoveCity_ContestLobby.inc
+++ b/data/scripts/maps/LilycoveCity_ContestLobby.inc
@@ -72,13 +72,13 @@ LilycoveCity_ContestLobby_EventScript_158948:: @ 8158948
 	special sub_80C4858
 	applymovement 4, LilycoveCity_ContestLobby_Movement_158A4E
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 4, LilycoveCity_ContestLobby_Movement_1A0833
 	waitmovement 0
 	applymovement 4, LilycoveCity_ContestLobby_Movement_158A52
 	waitmovement 0
 	msgbox LilycoveCity_ContestLobby_Text_188BB5, 4
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	msgbox LilycoveCity_ContestLobby_Text_188C03, 4
 	waitfanfare
 	msgbox LilycoveCity_ContestLobby_Text_188C19, 4
@@ -245,13 +245,13 @@ LilycoveCity_ContestLobby_EventScript_158B18:: @ 8158B18
 	special sub_80C4858
 	applymovement 11, LilycoveCity_ContestLobby_Movement_158B78
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 11, LilycoveCity_ContestLobby_Movement_1A0833
 	waitmovement 0
 	applymovement 11, LilycoveCity_ContestLobby_Movement_158B7C
 	waitmovement 0
 	msgbox LilycoveCity_ContestLobby_Text_188BB5, 4
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	msgbox LilycoveCity_ContestLobby_Text_188C03, 4
 	waitfanfare
 	msgbox LilycoveCity_ContestLobby_Text_188C19, 4
@@ -496,13 +496,13 @@ LilycoveCity_ContestLobby_EventScript_158E0B:: @ 8158E0B
 	closemessage
 	applymovement 2, LilycoveCity_ContestLobby_Movement_158E9C
 	waitmovement 0
-	playse 71
+	playse SE_HASHI
 	setmetatile 9, 2, 545, 1
 	setmetatile 9, 3, 609, 1
 	special DrawWholeMapView
 	applymovement 2, LilycoveCity_ContestLobby_Movement_158EA0
 	waitmovement 0
-	playse 71
+	playse SE_HASHI
 	setmetatile 9, 2, 721, 1
 	setmetatile 9, 3, 729, 1
 	special DrawWholeMapView
@@ -635,13 +635,13 @@ LilycoveCity_ContestLobby_EventScript_158F86:: @ 8158F86
 	lockall
 	applymovement 1, LilycoveCity_ContestLobby_Movement_15900B
 	waitmovement 0
-	playse 71
+	playse SE_HASHI
 	setmetatile 4, 2, 545, 1
 	setmetatile 4, 3, 609, 1
 	special DrawWholeMapView
 	applymovement 1, LilycoveCity_ContestLobby_Movement_15900F
 	waitmovement 0
-	playse 71
+	playse SE_HASHI
 	setmetatile 4, 2, 721, 1
 	setmetatile 4, 3, 729, 1
 	special DrawWholeMapView

--- a/data/scripts/maps/LilycoveCity_ContestLobby.inc
+++ b/data/scripts/maps/LilycoveCity_ContestLobby.inc
@@ -30,10 +30,10 @@ LilycoveCity_ContestLobby_EventScript_158898:: @ 8158898
 	fadescreen 1
 	drawcontestwinner 0
 	lockall
-	msgbox LilycoveCity_ContestLobby_Text_1889FD, 5
-	compare RESULT, 1
+	msgbox LilycoveCity_ContestLobby_Text_1889FD, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq LilycoveCity_ContestLobby_EventScript_1588DE
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq LilycoveCity_ContestLobby_EventScript_158918
 	releaseall
 	end
@@ -55,8 +55,8 @@ LilycoveCity_ContestLobby_EventScript_1588DE:: @ 81588DE
 	end
 
 LilycoveCity_ContestLobby_EventScript_158918:: @ 8158918
-	msgbox LilycoveCity_ContestLobby_Text_188C41, 5
-	compare RESULT, 1
+	msgbox LilycoveCity_ContestLobby_Text_188C41, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq LilycoveCity_ContestLobby_EventScript_1588DE
 	msgbox LilycoveCity_ContestLobby_Text_188CBD, 4
 	closemessage
@@ -204,10 +204,10 @@ LilycoveCity_ContestLobby_EventScript_158A6A:: @ 8158A6A
 	lockall
 	fadescreen 1
 	drawcontestwinner 0
-	msgbox LilycoveCity_ContestLobby_Text_1889FD, 5
-	compare RESULT, 1
+	msgbox LilycoveCity_ContestLobby_Text_1889FD, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq LilycoveCity_ContestLobby_EventScript_158AAE
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq LilycoveCity_ContestLobby_EventScript_158AE8
 	end
 
@@ -228,8 +228,8 @@ LilycoveCity_ContestLobby_EventScript_158AAE:: @ 8158AAE
 	end
 
 LilycoveCity_ContestLobby_EventScript_158AE8:: @ 8158AE8
-	msgbox LilycoveCity_ContestLobby_Text_188C41, 5
-	compare RESULT, 1
+	msgbox LilycoveCity_ContestLobby_Text_188C41, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq LilycoveCity_ContestLobby_EventScript_158AAE
 	msgbox LilycoveCity_ContestLobby_Text_188CBD, 4
 	closemessage
@@ -327,8 +327,8 @@ LilycoveCity_ContestLobby_EventScript_158BBA:: @ 8158BBA
 	end
 
 LilycoveCity_ContestLobby_EventScript_158BC4:: @ 8158BC4
-	msgbox LilycoveCity_ContestLobby_Text_188521, 5
-	compare RESULT, 0
+	msgbox LilycoveCity_ContestLobby_Text_188521, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq LilycoveCity_ContestLobby_EventScript_158C35
 	call S_DoSaveDialog
 	erasebox 0, 0, 15, 9

--- a/data/scripts/maps/LilycoveCity_CoveLilyMotel_1F.inc
+++ b/data/scripts/maps/LilycoveCity_CoveLilyMotel_1F.inc
@@ -41,7 +41,7 @@ LilycoveCity_CoveLilyMotel_1F_EventScript_158326:: @ 8158326
 
 LilycoveCity_CoveLilyMotel_1F_EventScript_15834D:: @ 815834D
 	lockall
-	playse 21
+	playse SE_PIN
 	applymovement 1, LilycoveCity_CoveLilyMotel_1F_Movement_1A0833
 	waitmovement 0
 	applymovement 1, LilycoveCity_CoveLilyMotel_1F_Movement_1A0835

--- a/data/scripts/maps/LilycoveCity_CoveLilyMotel_2F.inc
+++ b/data/scripts/maps/LilycoveCity_CoveLilyMotel_2F.inc
@@ -20,7 +20,7 @@ LilycoveCity_CoveLilyMotel_2F_EventScript_1583C7:: @ 81583C7
 
 LilycoveCity_CoveLilyMotel_2F_EventScript_1583D0:: @ 81583D0
 	setflag FLAG_TEMP_2
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	waitfanfare
 	goto LilycoveCity_CoveLilyMotel_2F_EventScript_1583DD
 	end

--- a/data/scripts/maps/LilycoveCity_DepartmentStoreRooftop.inc
+++ b/data/scripts/maps/LilycoveCity_DepartmentStoreRooftop.inc
@@ -147,7 +147,7 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_15A267:: @ 815A267
 	updatemoneybox 0, 0
 	nop
 	bufferitemname 0, VAR_TEMP_0
-	playse 106
+	playse SE_JIHANKI
 	msgbox LilycoveCity_DepartmentStoreRooftop_Text_18C75F, 4
 	giveitem VAR_TEMP_0, 1
 	bufferitemname 1, VAR_TEMP_0
@@ -159,7 +159,7 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_15A267:: @ 815A267
 	checkitemspace VAR_TEMP_0, 1
 	compare RESULT, 0
 	goto_if_eq LilycoveCity_DepartmentStoreRooftop_EventScript_15A388
-	playse 106
+	playse SE_JIHANKI
 	msgbox LilycoveCity_DepartmentStoreRooftop_Text_18C780, 4
 	giveitem VAR_TEMP_0, 1
 	bufferitemname 1, VAR_TEMP_0
@@ -171,7 +171,7 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_15A267:: @ 815A267
 	checkitemspace VAR_TEMP_0, 1
 	compare RESULT, 0
 	goto_if_eq LilycoveCity_DepartmentStoreRooftop_EventScript_15A388
-	playse 106
+	playse SE_JIHANKI
 	msgbox LilycoveCity_DepartmentStoreRooftop_Text_18C780, 4
 	giveitem VAR_TEMP_0, 1
 	bufferitemname 1, VAR_TEMP_0

--- a/data/scripts/maps/LilycoveCity_DepartmentStoreRooftop.inc
+++ b/data/scripts/maps/LilycoveCity_DepartmentStoreRooftop.inc
@@ -88,17 +88,17 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_15A1DE:: @ 815A1DE
 	end
 
 LilycoveCity_DepartmentStoreRooftop_EventScript_15A21C:: @ 815A21C
-	setvar VAR_TEMP_0, 26
+	setvar VAR_TEMP_0, ITEM_FRESH_WATER
 	goto LilycoveCity_DepartmentStoreRooftop_EventScript_15A267
 	end
 
 LilycoveCity_DepartmentStoreRooftop_EventScript_15A227:: @ 815A227
-	setvar VAR_TEMP_0, 27
+	setvar VAR_TEMP_0, ITEM_SODA_POP
 	goto LilycoveCity_DepartmentStoreRooftop_EventScript_15A267
 	end
 
 LilycoveCity_DepartmentStoreRooftop_EventScript_15A232:: @ 815A232
-	setvar VAR_TEMP_0, 28
+	setvar VAR_TEMP_0, ITEM_LEMONADE
 	goto LilycoveCity_DepartmentStoreRooftop_EventScript_15A267
 	end
 

--- a/data/scripts/maps/LilycoveCity_DepartmentStore_1F.inc
+++ b/data/scripts/maps/LilycoveCity_DepartmentStore_1F.inc
@@ -25,7 +25,7 @@ LilycoveCity_DepartmentStore_1F_EventScript_159D5E:: @ 8159D5E
 	msgbox LilycoveCity_DepartmentStore_1F_Text_1C4CF6, 4
 	applymovement 2, LilycoveCity_DepartmentStore_1F_Movement_1A0843
 	waitmovement 0
-	playse 4
+	playse SE_PC_ON
 	special DoLotteryCornerComputerEffect
 	special PickLotteryCornerTicket
 	delay 220

--- a/data/scripts/maps/LilycoveCity_DepartmentStore_1F.inc
+++ b/data/scripts/maps/LilycoveCity_DepartmentStore_1F.inc
@@ -13,8 +13,8 @@ LilycoveCity_DepartmentStore_1F_EventScript_159D5E:: @ 8159D5E
 	goto_if 5, LilycoveCity_DepartmentStore_1F_EventScript_159EB1
 	checkflag FLAG_DAILY_PICKED_LOTTO_TICKET
 	goto_if_eq LilycoveCity_DepartmentStore_1F_EventScript_159E4C
-	msgbox LilycoveCity_DepartmentStore_1F_Text_1C4B5E, 5
-	compare RESULT, 0
+	msgbox LilycoveCity_DepartmentStore_1F_Text_1C4B5E, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq LilycoveCity_DepartmentStore_1F_EventScript_159E56
 	setflag FLAG_DAILY_PICKED_LOTTO_TICKET
 	message LilycoveCity_DepartmentStore_1F_Text_1C4CC6

--- a/data/scripts/maps/LilycoveCity_Harbor.inc
+++ b/data/scripts/maps/LilycoveCity_Harbor.inc
@@ -47,8 +47,8 @@ LilycoveCity_Harbor_EventScript_159929:: @ 8159929
 	end
 
 LilycoveCity_Harbor_EventScript_159933:: @ 8159933
-	msgbox LilycoveCity_Harbor_Text_18B47D, 5
-	compare RESULT, 0
+	msgbox LilycoveCity_Harbor_Text_18B47D, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq LilycoveCity_Harbor_EventScript_15997E
 	setvar VAR_PORTHOLE_STATE, 5
 	call LilycoveCity_Harbor_EventScript_15998A
@@ -58,8 +58,8 @@ LilycoveCity_Harbor_EventScript_159933:: @ 8159933
 	end
 
 LilycoveCity_Harbor_EventScript_15995B:: @ 815995B
-	msgbox LilycoveCity_Harbor_Text_18B499, 5
-	compare RESULT, 0
+	msgbox LilycoveCity_Harbor_Text_18B499, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq LilycoveCity_Harbor_EventScript_15997E
 	call LilycoveCity_Harbor_EventScript_15998A
 	warp MAP_BATTLE_TOWER_OUTSIDE, 255, 19, 23

--- a/data/scripts/maps/LilycoveCity_House3.inc
+++ b/data/scripts/maps/LilycoveCity_House3.inc
@@ -10,8 +10,8 @@ LilycoveCity_House3_MapScript1_159BEA:: @ 8159BEA
 LilycoveCity_House3_EventScript_159BF3:: @ 8159BF3
 	lock
 	faceplayer
-	msgbox LilycoveCity_House3_Text_18B8CC, 5
-	compare RESULT, 0
+	msgbox LilycoveCity_House3_Text_18B8CC, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq LilycoveCity_House3_EventScript_159C1D
 	msgbox LilycoveCity_House3_Text_18BA2B, 4
 	closemessage

--- a/data/scripts/maps/LilycoveCity_LilycoveMuseum_1F.inc
+++ b/data/scripts/maps/LilycoveCity_LilycoveMuseum_1F.inc
@@ -22,10 +22,10 @@ LilycoveCity_LilycoveMuseum_1F_EventScript_15844F:: @ 815844F
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_158458:: @ 8158458
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_187495, 5
-	compare RESULT, 0
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_187495, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq LilycoveCity_LilycoveMuseum_1F_EventScript_158477
-	compare RESULT, 1
+	compare RESULT, YES
 	goto_if_eq LilycoveCity_LilycoveMuseum_1F_EventScript_158481
 	end
 

--- a/data/scripts/maps/LilycoveCity_MoveDeletersHouse.inc
+++ b/data/scripts/maps/LilycoveCity_MoveDeletersHouse.inc
@@ -40,7 +40,7 @@ LilycoveCity_MoveDeletersHouse_EventScript_159ADE:: @ 8159ADE
 
 LilycoveCity_MoveDeletersHouse_EventScript_159B53:: @ 8159B53
 	special DeleteMonMove
-	playfanfare 378
+	playfanfare BGM_ME_WASURE
 	waitfanfare
 	msgbox LilycoveCity_MoveDeletersHouse_Text_18B71E, 4
 	releaseall

--- a/data/scripts/maps/LilycoveCity_MoveDeletersHouse.inc
+++ b/data/scripts/maps/LilycoveCity_MoveDeletersHouse.inc
@@ -5,10 +5,10 @@ LilycoveCity_MoveDeletersHouse_EventScript_159AAE:: @ 8159AAE
 	lockall
 	applymovement 1, LilycoveCity_MoveDeletersHouse_Movement_1A0839
 	waitmovement 0
-	msgbox LilycoveCity_MoveDeletersHouse_Text_18B622, 5
+	msgbox LilycoveCity_MoveDeletersHouse_Text_18B622, MSGBOX_YESNO
 	switch RESULT
-	case 1, LilycoveCity_MoveDeletersHouse_EventScript_159ADE
-	case 0, LilycoveCity_MoveDeletersHouse_EventScript_159B7B
+	case YES, LilycoveCity_MoveDeletersHouse_EventScript_159ADE
+	case NO, LilycoveCity_MoveDeletersHouse_EventScript_159B7B
 	releaseall
 	end
 
@@ -31,10 +31,10 @@ LilycoveCity_MoveDeletersHouse_EventScript_159ADE:: @ 8159ADE
 	compare VAR_SPECIAL_5, 4
 	goto_if_eq LilycoveCity_MoveDeletersHouse_EventScript_159ADE
 	special ScrSpecial_GetPokemonNicknameAndMoveName
-	msgbox LilycoveCity_MoveDeletersHouse_Text_18B6F2, 5
+	msgbox LilycoveCity_MoveDeletersHouse_Text_18B6F2, MSGBOX_YESNO
 	switch RESULT
-	case 1, LilycoveCity_MoveDeletersHouse_EventScript_159B53
-	case 0, LilycoveCity_MoveDeletersHouse_EventScript_159B7B
+	case YES, LilycoveCity_MoveDeletersHouse_EventScript_159B53
+	case NO, LilycoveCity_MoveDeletersHouse_EventScript_159B7B
 	releaseall
 	end
 

--- a/data/scripts/maps/LittlerootTown.inc
+++ b/data/scripts/maps/LittlerootTown.inc
@@ -99,7 +99,7 @@ LittlerootTown_EventScript_14D60D:: @ 814D60D
 
 LittlerootTown_EventScript_14D62B:: @ 814D62B
 	delay 15
-	playse 10
+	playse SE_DANSA
 	applymovement 255, LittlerootTown_Movement_14D6C0
 	waitmovement 0
 	opendoor VAR_SPECIAL_4, VAR_SPECIAL_5
@@ -868,7 +868,7 @@ LittlerootTown_EventScript_14DD2B:: @ 814DD2B
 
 LittlerootTown_EventScript_14DD38:: @ 814DD38
 	msgbox LittlerootTown_Text_16A8FD, 4
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	message LittlerootTown_Text_16AA32
 	waitfanfare
 	waitmessage

--- a/data/scripts/maps/LittlerootTown_BrendansHouse_1F.inc
+++ b/data/scripts/maps/LittlerootTown_BrendansHouse_1F.inc
@@ -90,7 +90,7 @@ LittlerootTown_BrendansHouse_1F_EventScript_152733:: @ 8152733
 
 LittlerootTown_BrendansHouse_1F_EventScript_152744:: @ 8152744
 	lockall
-	playse 21
+	playse SE_PIN
 	applymovement 4, LittlerootTown_BrendansHouse_1F_Movement_1A0833
 	waitmovement 0
 	applymovement 4, LittlerootTown_BrendansHouse_1F_Movement_1A0835

--- a/data/scripts/maps/LittlerootTown_MaysHouse_1F.inc
+++ b/data/scripts/maps/LittlerootTown_MaysHouse_1F.inc
@@ -90,7 +90,7 @@ LittlerootTown_MaysHouse_1F_EventScript_152971:: @ 8152971
 
 LittlerootTown_MaysHouse_1F_EventScript_152982:: @ 8152982
 	lockall
-	playse 21
+	playse SE_PIN
 	applymovement 4, LittlerootTown_MaysHouse_1F_Movement_1A0833
 	waitmovement 0
 	applymovement 4, LittlerootTown_MaysHouse_1F_Movement_1A0835

--- a/data/scripts/maps/LittlerootTown_MaysHouse_2F.inc
+++ b/data/scripts/maps/LittlerootTown_MaysHouse_2F.inc
@@ -37,7 +37,7 @@ LittlerootTown_MaysHouse_2F_EventScript_152A9D:: @ 8152A9D
 	call_if 1, LittlerootTown_BrendansHouse_2F_EventScript_152AD4
 	compare RESULT, 1
 	call_if 1, LittlerootTown_BrendansHouse_2F_EventScript_152B4A
-	playse 9
+	playse SE_KAIDAN
 	removeobject LAST_TALKED
 	setvar VAR_LITTLEROOT_RIVAL_STATE, 3
 	setvar VAR_LITTLEROOT_STATE, 1
@@ -48,7 +48,7 @@ LittlerootTown_MaysHouse_2F_EventScript_152A9D:: @ 8152A9D
 
 LittlerootTown_BrendansHouse_2F_EventScript_152AD4:: @ 8152AD4
 	msgbox LittlerootTown_BrendansHouse_2F_Text_17337E, 4
-	playbgm 415, 1
+	playbgm BGM_GIRL_SUP, TRUE
 	applymovement LAST_TALKED, LittlerootTown_BrendansHouse_2F_Movement_1A0839
 	waitmovement 0
 	applymovement LAST_TALKED, LittlerootTown_BrendansHouse_2F_Movement_1A0833
@@ -82,7 +82,7 @@ LittlerootTown_BrendansHouse_2F_EventScript_152B3F:: @ 8152B3F
 
 LittlerootTown_BrendansHouse_2F_EventScript_152B4A:: @ 8152B4A
 	msgbox LittlerootTown_BrendansHouse_2F_Text_1735C9, 4
-	playbgm 421, 1
+	playbgm BGM_BOY_SUP, TRUE
 	applymovement LAST_TALKED, LittlerootTown_BrendansHouse_2F_Movement_1A0839
 	waitmovement 0
 	applymovement LAST_TALKED, LittlerootTown_BrendansHouse_2F_Movement_1A0833

--- a/data/scripts/maps/LittlerootTown_ProfessorBirchsLab.inc
+++ b/data/scripts/maps/LittlerootTown_ProfessorBirchsLab.inc
@@ -29,10 +29,10 @@ LittlerootTown_ProfessorBirchsLab_EventScript_152CBE:: @ 8152CBE
 	waitmessage
 	playfanfare BGM_FANFA4
 	waitfanfare
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_173EF8, 5
-	compare RESULT, 1
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_173EF8, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq LittlerootTown_ProfessorBirchsLab_EventScript_152CEA
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq LittlerootTown_ProfessorBirchsLab_EventScript_152CFA
 	end
 
@@ -43,10 +43,10 @@ LittlerootTown_ProfessorBirchsLab_EventScript_152CEA:: @ 8152CEA
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_152CFA:: @ 8152CFA
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_173F3D, 5
-	compare RESULT, 1
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_173F3D, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq LittlerootTown_ProfessorBirchsLab_EventScript_152D19
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq LittlerootTown_ProfessorBirchsLab_EventScript_152D2B
 	end
 
@@ -58,10 +58,10 @@ LittlerootTown_ProfessorBirchsLab_EventScript_152D19:: @ 8152D19
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_152D2B:: @ 8152D2B
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_174075, 5
-	compare RESULT, 1
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_174075, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq LittlerootTown_ProfessorBirchsLab_EventScript_152D19
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq LittlerootTown_ProfessorBirchsLab_EventScript_152D2B
 	end
 

--- a/data/scripts/maps/LittlerootTown_ProfessorBirchsLab.inc
+++ b/data/scripts/maps/LittlerootTown_ProfessorBirchsLab.inc
@@ -27,7 +27,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_152CBE:: @ 8152CBE
 	bufferleadmonspeciesname 0
 	message LittlerootTown_ProfessorBirchsLab_Text_173D94
 	waitmessage
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	waitfanfare
 	msgbox LittlerootTown_ProfessorBirchsLab_Text_173EF8, 5
 	compare RESULT, 1
@@ -155,7 +155,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_152E40:: @ 8152E40
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_152E6D:: @ 8152E6D
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	message LittlerootTown_ProfessorBirchsLab_Text_17422F
 	waitfanfare
 	waitmessage

--- a/data/scripts/maps/MauvilleCity.inc
+++ b/data/scripts/maps/MauvilleCity.inc
@@ -100,14 +100,14 @@ MauvilleCity_EventScript_14C0F9:: @ 814C0F9
 	waitmovement 0
 	applymovement 6, MauvilleCity_Movement_1A0835
 	waitmovement 0
-	msgbox MauvilleCity_Text_165D50, 5
+	msgbox MauvilleCity_Text_165D50, MSGBOX_YESNO
 	goto MauvilleCity_EventScript_14C154
 	end
 
 MauvilleCity_EventScript_14C154:: @ 814C154
-	compare RESULT, 1
+	compare RESULT, YES
 	call_if 1, MauvilleCity_EventScript_14C23C
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq MauvilleCity_EventScript_14C285
 	closemessage
 	switch FACING
@@ -185,7 +185,7 @@ MauvilleCity_EventScript_14C285:: @ 814C285
 MauvilleCity_EventScript_14C292:: @ 814C292
 	applymovement 6, MauvilleCity_Movement_1A0839
 	waitmovement 0
-	msgbox MauvilleCity_Text_165EE2, 5
+	msgbox MauvilleCity_Text_165EE2, MSGBOX_YESNO
 	goto MauvilleCity_EventScript_14C154
 	end
 

--- a/data/scripts/maps/MauvilleCity.inc
+++ b/data/scripts/maps/MauvilleCity.inc
@@ -95,7 +95,7 @@ MauvilleCity_EventScript_14C0F9:: @ 814C0F9
 	msgbox MauvilleCity_Text_165D01, 4
 	applymovement 6, MauvilleCity_Movement_1A0839
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 6, MauvilleCity_Movement_1A0833
 	waitmovement 0
 	applymovement 6, MauvilleCity_Movement_1A0835

--- a/data/scripts/maps/MauvilleCity_BikeShop.inc
+++ b/data/scripts/maps/MauvilleCity_BikeShop.inc
@@ -9,18 +9,18 @@ MauvilleCity_BikeShop_EventScript_156796:: @ 8156796
 	checkflag FLAG_DECLINED_BIKE
 	goto_if_eq MauvilleCity_BikeShop_EventScript_1567D1
 	msgbox MauvilleCity_BikeShop_Text_180F9F, 4
-	msgbox MauvilleCity_BikeShop_Text_181016, 5
-	compare RESULT, 1
+	msgbox MauvilleCity_BikeShop_Text_181016, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq MauvilleCity_BikeShop_EventScript_156824
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq MauvilleCity_BikeShop_EventScript_156817
 	end
 
 MauvilleCity_BikeShop_EventScript_1567D1:: @ 81567D1
-	msgbox MauvilleCity_BikeShop_Text_181016, 5
-	compare RESULT, 1
+	msgbox MauvilleCity_BikeShop_Text_181016, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq MauvilleCity_BikeShop_EventScript_156824
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq MauvilleCity_BikeShop_EventScript_156817
 	end
 
@@ -63,10 +63,10 @@ MauvilleCity_BikeShop_EventScript_156861:: @ 8156861
 	end
 
 MauvilleCity_BikeShop_EventScript_15686E:: @ 815686E
-	msgbox MauvilleCity_BikeShop_Text_1813A0, 5
-	compare RESULT, 1
+	msgbox MauvilleCity_BikeShop_Text_1813A0, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq MauvilleCity_BikeShop_EventScript_15688D
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq MauvilleCity_BikeShop_EventScript_1568BF
 	end
 

--- a/data/scripts/maps/MauvilleCity_GameCorner.inc
+++ b/data/scripts/maps/MauvilleCity_GameCorner.inc
@@ -143,8 +143,8 @@ MauvilleCity_GameCorner_EventScript_156BFE:: @ 8156BFE
 	goto MauvilleCity_GameCorner_EventScript_156C0C
 
 MauvilleCity_GameCorner_EventScript_156C0C:: @ 8156C0C
-	msgbox MauvilleCity_GameCorner_Text_181E33, 5
-	compare RESULT, 0
+	msgbox MauvilleCity_GameCorner_Text_181E33, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq MauvilleCity_GameCorner_EventScript_156D0D
 	switch VAR_TEMP_1
 	case 1, MauvilleCity_GameCorner_EventScript_156C46
@@ -276,8 +276,8 @@ MauvilleCity_GameCorner_EventScript_156DDE:: @ 8156DDE
 	goto MauvilleCity_GameCorner_EventScript_156DEC
 
 MauvilleCity_GameCorner_EventScript_156DEC:: @ 8156DEC
-	msgbox MauvilleCity_GameCorner_Text_181E33, 5
-	compare RESULT, 0
+	msgbox MauvilleCity_GameCorner_Text_181E33, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq MauvilleCity_GameCorner_EventScript_156F77
 	switch VAR_TEMP_1
 	case 1, MauvilleCity_GameCorner_EventScript_156E3C
@@ -391,8 +391,8 @@ MauvilleCity_GameCorner_EventScript_156F96:: @ 8156F96
 	faceplayer
 	checkflag FLAG_RECEIVED_STARTER_DOLL
 	goto_if_eq MauvilleCity_GameCorner_EventScript_157072
-	msgbox MauvilleCity_GameCorner_Text_181F3D, 5
-	compare RESULT, 0
+	msgbox MauvilleCity_GameCorner_Text_181F3D, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq MauvilleCity_GameCorner_EventScript_157068
 	switch VAR_STARTER_MON
 	case 0, MauvilleCity_GameCorner_EventScript_156FDB

--- a/data/scripts/maps/MauvilleCity_GameCorner.inc
+++ b/data/scripts/maps/MauvilleCity_GameCorner.inc
@@ -156,12 +156,12 @@ MauvilleCity_GameCorner_EventScript_156C46:: @ 8156C46
 	checkcoins VAR_TEMP_2
 	compare VAR_TEMP_2, 1000
 	goto_if 0, MauvilleCity_GameCorner_EventScript_156CF4
-	bufferdecorationname 1, 88
-	checkdecorspace 88
+	bufferdecorationname 1, DECOR_TREECKO_DOLL
+	checkdecorspace DECOR_TREECKO_DOLL
 	compare RESULT, 0
 	goto_if_eq MauvilleCity_GameCorner_EventScript_156D02
 	takecoins 1000
-	givedecoration 88
+	givedecoration DECOR_TREECKO_DOLL
 	updatecoinsbox 0, 0
 	playse SE_REGI
 	msgbox MauvilleCity_GameCorner_Text_181E49, 4
@@ -172,12 +172,12 @@ MauvilleCity_GameCorner_EventScript_156C80:: @ 8156C80
 	checkcoins VAR_TEMP_2
 	compare VAR_TEMP_2, 1000
 	goto_if 0, MauvilleCity_GameCorner_EventScript_156CF4
-	bufferdecorationname 1, 89
-	checkdecorspace 89
+	bufferdecorationname 1, DECOR_TORCHIC_DOLL
+	checkdecorspace DECOR_TORCHIC_DOLL
 	compare RESULT, 0
 	goto_if_eq MauvilleCity_GameCorner_EventScript_156D02
 	takecoins 1000
-	givedecoration 89
+	givedecoration DECOR_TORCHIC_DOLL
 	updatecoinsbox 0, 0
 	playse SE_REGI
 	msgbox MauvilleCity_GameCorner_Text_181E49, 4
@@ -188,12 +188,12 @@ MauvilleCity_GameCorner_EventScript_156CBA:: @ 8156CBA
 	checkcoins VAR_TEMP_2
 	compare VAR_TEMP_2, 1000
 	goto_if 0, MauvilleCity_GameCorner_EventScript_156CF4
-	bufferdecorationname 1, 90
-	checkdecorspace 90
+	bufferdecorationname 1, DECOR_MUDKIP_DOLL
+	checkdecorspace DECOR_MUDKIP_DOLL
 	compare RESULT, 0
 	goto_if_eq MauvilleCity_GameCorner_EventScript_156D02
 	takecoins 1000
-	givedecoration 90
+	givedecoration DECOR_MUDKIP_DOLL
 	updatecoinsbox 0, 0
 	playse SE_REGI
 	msgbox MauvilleCity_GameCorner_Text_181E49, 4

--- a/data/scripts/maps/MauvilleCity_GameCorner.inc
+++ b/data/scripts/maps/MauvilleCity_GameCorner.inc
@@ -43,7 +43,7 @@ MauvilleCity_GameCorner_EventScript_156AAE:: @ 8156AAE
 	updatemoneybox 0, 0
 	nop
 	updatecoinsbox 0, 5
-	playse 95
+	playse SE_REGI
 	msgbox MauvilleCity_GameCorner_Text_181CFE, 4
 	hidemoneybox 0, 0
 	hidecoinsbox 0, 5
@@ -62,7 +62,7 @@ MauvilleCity_GameCorner_EventScript_156AF0:: @ 8156AF0
 	updatemoneybox 0, 0
 	nop
 	updatecoinsbox 0, 5
-	playse 95
+	playse SE_REGI
 	msgbox MauvilleCity_GameCorner_Text_181CFE, 4
 	hidemoneybox 0, 0
 	hidecoinsbox 0, 5
@@ -163,7 +163,7 @@ MauvilleCity_GameCorner_EventScript_156C46:: @ 8156C46
 	takecoins 1000
 	givedecoration 88
 	updatecoinsbox 0, 0
-	playse 95
+	playse SE_REGI
 	msgbox MauvilleCity_GameCorner_Text_181E49, 4
 	goto MauvilleCity_GameCorner_EventScript_156B9B
 	end
@@ -179,7 +179,7 @@ MauvilleCity_GameCorner_EventScript_156C80:: @ 8156C80
 	takecoins 1000
 	givedecoration 89
 	updatecoinsbox 0, 0
-	playse 95
+	playse SE_REGI
 	msgbox MauvilleCity_GameCorner_Text_181E49, 4
 	goto MauvilleCity_GameCorner_EventScript_156B9B
 	end
@@ -195,7 +195,7 @@ MauvilleCity_GameCorner_EventScript_156CBA:: @ 8156CBA
 	takecoins 1000
 	givedecoration 90
 	updatecoinsbox 0, 0
-	playse 95
+	playse SE_REGI
 	msgbox MauvilleCity_GameCorner_Text_181E49, 4
 	goto MauvilleCity_GameCorner_EventScript_156B9B
 	end
@@ -297,7 +297,7 @@ MauvilleCity_GameCorner_EventScript_156E3C:: @ 8156E3C
 	takecoins 1500
 	giveitem ITEM_TM32, 1
 	updatecoinsbox 0, 0
-	playse 95
+	playse SE_REGI
 	msgbox MauvilleCity_GameCorner_Text_181F08, 4
 	goto MauvilleCity_GameCorner_EventScript_156D49
 	end
@@ -312,7 +312,7 @@ MauvilleCity_GameCorner_EventScript_156E76:: @ 8156E76
 	takecoins 3500
 	giveitem ITEM_TM29, 1
 	updatecoinsbox 0, 0
-	playse 95
+	playse SE_REGI
 	msgbox MauvilleCity_GameCorner_Text_181F08, 4
 	goto MauvilleCity_GameCorner_EventScript_156D49
 	end
@@ -327,7 +327,7 @@ MauvilleCity_GameCorner_EventScript_156EB0:: @ 8156EB0
 	takecoins 4000
 	giveitem ITEM_TM35, 1
 	updatecoinsbox 0, 0
-	playse 95
+	playse SE_REGI
 	msgbox MauvilleCity_GameCorner_Text_181F08, 4
 	goto MauvilleCity_GameCorner_EventScript_156D49
 	end
@@ -342,7 +342,7 @@ MauvilleCity_GameCorner_EventScript_156EEA:: @ 8156EEA
 	takecoins 4000
 	giveitem ITEM_TM24, 1
 	updatecoinsbox 0, 0
-	playse 95
+	playse SE_REGI
 	msgbox MauvilleCity_GameCorner_Text_181F08, 4
 	goto MauvilleCity_GameCorner_EventScript_156D49
 	end
@@ -357,7 +357,7 @@ MauvilleCity_GameCorner_EventScript_156F24:: @ 8156F24
 	takecoins 4000
 	giveitem ITEM_TM13, 1
 	updatecoinsbox 0, 0
-	playse 95
+	playse SE_REGI
 	msgbox MauvilleCity_GameCorner_Text_181F08, 4
 	goto MauvilleCity_GameCorner_EventScript_156D49
 	end
@@ -468,7 +468,7 @@ MauvilleCity_GameCorner_EventScript_15709C:: @ 815709C
 	setflag FLAG_RECEIVED_20_COINS
 	givecoins 20
 	msgbox MauvilleCity_GameCorner_Text_18208E, 4
-	playse 95
+	playse SE_REGI
 	goto MauvilleCity_GameCorner_EventScript_1570CA
 	end
 

--- a/data/scripts/maps/MauvilleCity_Gym.inc
+++ b/data/scripts/maps/MauvilleCity_Gym.inc
@@ -91,7 +91,7 @@ MauvilleCity_Gym_EventScript_1565DB:: @ 81565DB
 	call MauvilleCity_Gym_EventScript_1A01C0
 	special MauvilleGymSpecial3
 	special DrawWholeMapView
-	playse 44
+	playse SE_KI_GASYAN
 	goto MauvilleCity_Gym_EventScript_15661D
 	end
 
@@ -146,7 +146,7 @@ MauvilleCity_Gym_EventScript_1566BA:: @ 81566BA
 	special MauvilleGymSpecial2
 	special MauvilleGymSpecial1
 	special DrawWholeMapView
-	playse 44
+	playse SE_KI_GASYAN
 	checkflag FLAG_MAUVILLE_GYM_BARRIERS_STATE
 	goto_if_eq MauvilleCity_Gym_EventScript_1566E1
 	checkflag FLAG_MAUVILLE_GYM_BARRIERS_STATE

--- a/data/scripts/maps/MauvilleCity_House2.inc
+++ b/data/scripts/maps/MauvilleCity_House2.inc
@@ -19,10 +19,10 @@ MauvilleCity_House2_EventScript_1572E5:: @ 81572E5
 	waitmovement 0
 	applymovement LAST_TALKED, MauvilleCity_House2_Movement_1A0835
 	waitmovement 0
-	msgbox MauvilleCity_House2_Text_1824D8, 5
-	compare RESULT, 1
+	msgbox MauvilleCity_House2_Text_1824D8, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq MauvilleCity_House2_EventScript_15731B
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq MauvilleCity_House2_EventScript_157347
 	end
 

--- a/data/scripts/maps/MauvilleCity_House2.inc
+++ b/data/scripts/maps/MauvilleCity_House2.inc
@@ -14,7 +14,7 @@ MauvilleCity_House2_EventScript_1572C0:: @ 81572C0
 	end
 
 MauvilleCity_House2_EventScript_1572E5:: @ 81572E5
-	playse 21
+	playse SE_PIN
 	applymovement LAST_TALKED, MauvilleCity_House2_Movement_1A0833
 	waitmovement 0
 	applymovement LAST_TALKED, MauvilleCity_House2_Movement_1A0835

--- a/data/scripts/maps/MeteorFalls_1F_1R.inc
+++ b/data/scripts/maps/MeteorFalls_1F_1R.inc
@@ -18,7 +18,7 @@ MeteorFalls_1F_1R_EventScript_15C49C:: @ 815C49C
 	applymovement 5, MeteorFalls_1F_1R_Movement_1A0841
 	applymovement 6, MeteorFalls_1F_1R_Movement_1A0841
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 5, MeteorFalls_1F_1R_Movement_1A0833
 	waitmovement 0
 	applymovement 5, MeteorFalls_1F_1R_Movement_1A0835

--- a/data/scripts/maps/MossdeepCity.inc
+++ b/data/scripts/maps/MossdeepCity.inc
@@ -70,8 +70,8 @@ MossdeepCity_EventScript_14D027:: @ 814D027
 	faceplayer
 	checkflag FLAG_RECEIVED_KINGS_ROCK
 	goto_if_eq MossdeepCity_EventScript_14D069
-	msgbox MossdeepCity_Text_1690A9, 5
-	compare RESULT, 0
+	msgbox MossdeepCity_Text_1690A9, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq MossdeepCity_EventScript_14D073
 	msgbox MossdeepCity_Text_169117, 4
 	giveitem_std ITEM_KINGS_ROCK

--- a/data/scripts/maps/MossdeepCity_GameCorner_1F.inc
+++ b/data/scripts/maps/MossdeepCity_GameCorner_1F.inc
@@ -93,14 +93,14 @@ MossdeepCity_GameCorner_1F_EventScript_15AD42:: @ 815AD42
 MossdeepCity_GameCorner_1F_EventScript_15AD59:: @ 815AD59
 	special SavePlayerParty
 	special BufferEReaderTrainerName
-	msgbox MossdeepCity_GameCorner_1F_Text_18E650, 5
-	compare RESULT, 0
+	msgbox MossdeepCity_GameCorner_1F_Text_18E650, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq MossdeepCity_GameCorner_1F_EventScript_15ADE8
 	call MossdeepCity_GameCorner_1F_EventScript_15ADF5
 	compare RESULT, 0
 	goto_if_eq MossdeepCity_GameCorner_1F_EventScript_15ADE8
-	msgbox MossdeepCity_GameCorner_1F_Text_18E741, 5
-	compare RESULT, 0
+	msgbox MossdeepCity_GameCorner_1F_Text_18E741, MSGBOX_YESNO
+	compare RESULT, NO
 	call_if 1, MossdeepCity_GameCorner_1F_EventScript_15ADE8
 	special LoadPlayerParty
 	call S_DoSaveDialog

--- a/data/scripts/maps/MossdeepCity_Gym.inc
+++ b/data/scripts/maps/MossdeepCity_Gym.inc
@@ -94,7 +94,7 @@ MossdeepCity_Gym_EventScript_15A5EA:: @ 815A5EA
 
 MossdeepCity_Gym_EventScript_15A619:: @ 815A619
 	special DrawWholeMapView
-	playse 36
+	playse SE_TK_KASYA
 	releaseall
 	end
 

--- a/data/scripts/maps/MossdeepCity_House3.inc
+++ b/data/scripts/maps/MossdeepCity_House3.inc
@@ -6,8 +6,8 @@ MossdeepCity_House3_EventScript_15A972:: @ 815A972
 	faceplayer
 	checkflag FLAG_RECEIVED_SUPER_ROD
 	goto_if_eq MossdeepCity_House3_EventScript_15A9B1
-	msgbox MossdeepCity_House3_Text_18D909, 5
-	compare RESULT, 0
+	msgbox MossdeepCity_House3_Text_18D909, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq MossdeepCity_House3_EventScript_15A9BB
 	msgbox MossdeepCity_House3_Text_18D9A9, 4
 	giveitem_std ITEM_SUPER_ROD

--- a/data/scripts/maps/MossdeepCity_StevensHouse.inc
+++ b/data/scripts/maps/MossdeepCity_StevensHouse.inc
@@ -31,7 +31,7 @@ MossdeepCity_StevensHouse_EventScript_15AA0B:: @ 815AA0B
 	lockall
 	applymovement 1, MossdeepCity_StevensHouse_Movement_1A083F
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 1, MossdeepCity_StevensHouse_Movement_1A0833
 	waitmovement 0
 	applymovement 1, MossdeepCity_StevensHouse_Movement_1A0835
@@ -79,7 +79,7 @@ MossdeepCity_StevensHouse_EventScript_15AA7C:: @ 815AA7C
 	goto_if_eq MossdeepCity_StevensHouse_EventScript_15AADC
 	copyvar VAR_SPECIAL_4, RESULT
 	removeobject 2
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	message MossdeepCity_StevensHouse_Text_18DD61
 	waitfanfare
 	waitmessage

--- a/data/scripts/maps/MossdeepCity_StevensHouse.inc
+++ b/data/scripts/maps/MossdeepCity_StevensHouse.inc
@@ -71,8 +71,8 @@ MossdeepCity_StevensHouse_Movement_15AA76:: @ 815AA76
 
 MossdeepCity_StevensHouse_EventScript_15AA7C:: @ 815AA7C
 	lockall
-	msgbox MossdeepCity_StevensHouse_Text_18DD12, 5
-	compare RESULT, 0
+	msgbox MossdeepCity_StevensHouse_Text_18DD12, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq MossdeepCity_StevensHouse_EventScript_15AAE6
 	getpartysize
 	compare RESULT, 6
@@ -85,8 +85,8 @@ MossdeepCity_StevensHouse_EventScript_15AA7C:: @ 815AA7C
 	waitmessage
 	givemon SPECIES_BELDUM, 5, ITEM_NONE, 0x0, 0x0, 0
 	bufferspeciesname 1, SPECIES_BELDUM
-	msgbox MossdeepCity_StevensHouse_Text_1A1102, 5
-	compare RESULT, 1
+	msgbox MossdeepCity_StevensHouse_Text_1A1102, MSGBOX_YESNO
+	compare RESULT, YES
 	call_if 1, MossdeepCity_StevensHouse_EventScript_1A0678
 	setflag FLAG_HIDE_BELDUM_BALL_STEVENS_HOUSE
 	setflag FLAG_RECEIVED_BELDUM

--- a/data/scripts/maps/MtChimney.inc
+++ b/data/scripts/maps/MtChimney.inc
@@ -17,8 +17,8 @@ MtChimney_EventScript_15CF95:: @ 815CF95
 	faceplayer
 	showmoneybox 0, 0
 	nop
-	msgbox MtChimney_Text_195760, 5
-	compare RESULT, 0
+	msgbox MtChimney_Text_195760, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq MtChimney_EventScript_15D00B
 	checkmoney 0xc8, 0
 	compare RESULT, 0
@@ -410,8 +410,8 @@ MtChimney_EventScript_15D17D:: @ 815D17D
 	goto_if 0, MtChimney_EventScript_15D1D0
 	checkflag FLAG_RECEIVED_METEORITE
 	goto_if_eq MtChimney_EventScript_15D1C6
-	msgbox MtChimney_Text_195870, 5
-	compare RESULT, 0
+	msgbox MtChimney_Text_195870, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq MtChimney_EventScript_15D1BC
 	msgbox MtChimney_Text_1958C6, 4
 	giveitem_std ITEM_METEORITE

--- a/data/scripts/maps/MtChimney_CableCarStation.inc
+++ b/data/scripts/maps/MtChimney_CableCarStation.inc
@@ -31,10 +31,10 @@ MtChimney_CableCarStation_EventScript_15C127:: @ 815C127
 MtChimney_CableCarStation_EventScript_15C14B:: @ 815C14B
 	lock
 	faceplayer
-	msgbox MtChimney_CableCarStation_Text_19256A, 5
-	compare RESULT, 1
+	msgbox MtChimney_CableCarStation_Text_19256A, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq MtChimney_CableCarStation_EventScript_15C16C
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq MtChimney_CableCarStation_EventScript_15C19B
 	end
 

--- a/data/scripts/maps/MtPyre_Exterior.inc
+++ b/data/scripts/maps/MtPyre_Exterior.inc
@@ -13,15 +13,15 @@ MtPyre_Exterior_EventScript_15D492:: @ 815D492
 	return
 
 MtPyre_Exterior_EventScript_15D4A3:: @ 815D4A3
-	setweather 6
+	setweather WEATHER_FOG_1
 	return
 
 MtPyre_Exterior_EventScript_15D4A7:: @ 815D4A7
-	setweather 6
+	setweather WEATHER_FOG_1
 	doweather
 	end
 
 MtPyre_Exterior_EventScript_15D4AC:: @ 815D4AC
-	setweather 2
+	setweather WEATHER_SUNNY
 	doweather
 	end

--- a/data/scripts/maps/MtPyre_Summit.inc
+++ b/data/scripts/maps/MtPyre_Summit.inc
@@ -139,13 +139,13 @@ MtPyre_Summit_EventScript_15D5EF:: @ 815D5EF
 	lock
 	faceplayer
 	.ifdef SAPPHIRE
-	msgbox UnknownString_81B586F, 5
+	msgbox UnknownString_81B586F, MSGBOX_YESNO
 	.else
-	msgbox MtPyre_Summit_Text_1B64B3, 5
+	msgbox MtPyre_Summit_Text_1B64B3, MSGBOX_YESNO
 	.endif
-	compare RESULT, 1
+	compare RESULT, YES
 	call_if 1, MtPyre_Summit_EventScript_15D611
-	compare RESULT, 0
+	compare RESULT, NO
 	call_if 1, MtPyre_Summit_EventScript_15D61A
 	release
 	end
@@ -185,13 +185,13 @@ MtPyre_Summit_EventScript_15D623:: @ 815D623
 
 MtPyre_Summit_EventScript_15D64A:: @ 815D64A
 	.ifdef SAPPHIRE
-	msgbox UnknownString_81B5647, 5
+	msgbox UnknownString_81B5647, MSGBOX_YESNO
 	.else
-	msgbox MtPyre_Summit_Text_1B6283, 5
+	msgbox MtPyre_Summit_Text_1B6283, MSGBOX_YESNO
 	.endif
-	compare RESULT, 1
+	compare RESULT, YES
 	goto_if_eq MtPyre_Summit_EventScript_15D669
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq MtPyre_Summit_EventScript_15D69B
 	end
 
@@ -216,13 +216,13 @@ MtPyre_Summit_EventScript_15D669:: @ 815D669
 
 MtPyre_Summit_EventScript_15D69B:: @ 815D69B
 	.ifdef SAPPHIRE
-	msgbox UnknownString_81B56AB, 5
+	msgbox UnknownString_81B56AB, MSGBOX_YESNO
 	.else
-	msgbox MtPyre_Summit_Text_1B62E7, 5
+	msgbox MtPyre_Summit_Text_1B62E7, MSGBOX_YESNO
 	.endif
-	compare RESULT, 1
+	compare RESULT, YES
 	goto_if_eq MtPyre_Summit_EventScript_15D669
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq MtPyre_Summit_EventScript_15D69B
 	end
 

--- a/data/scripts/maps/NewMauville_Entrance.inc
+++ b/data/scripts/maps/NewMauville_Entrance.inc
@@ -40,7 +40,7 @@ NewMauville_Entrance_EventScript_15E4DC:: @ 815E4DC
 	setmetatile 4, 1, 716, 0
 	setmetatile 5, 1, 717, 1
 	special DrawWholeMapView
-	playse 20
+	playse SE_BAN
 	setvar VAR_NEW_MAUVILLE_STATE, 1
 	releaseall
 	end

--- a/data/scripts/maps/NewMauville_Entrance.inc
+++ b/data/scripts/maps/NewMauville_Entrance.inc
@@ -29,8 +29,8 @@ NewMauville_Entrance_EventScript_15E4DC:: @ 815E4DC
 	checkitem ITEM_BASEMENT_KEY, 1
 	compare RESULT, 0
 	goto_if_eq NewMauville_Entrance_EventScript_15E55D
-	msgbox NewMauville_Entrance_Text_1982D4, 5
-	compare RESULT, 0
+	msgbox NewMauville_Entrance_Text_1982D4, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq NewMauville_Entrance_EventScript_15E55D
 	msgbox NewMauville_Entrance_Text_1982EA, 4
 	setmetatile 3, 0, 707, 0

--- a/data/scripts/maps/NewMauville_Inside.inc
+++ b/data/scripts/maps/NewMauville_Inside.inc
@@ -31,7 +31,7 @@ NewMauville_Inside_EventScript_15E5AA:: @ 815E5AA
 	lockall
 	setvar VAR_TEMP_1, 1
 	setvar VAR_TEMP_2, 0
-	playse 21
+	playse SE_PIN
 	call NewMauville_Inside_EventScript_15E5DA
 	special DrawWholeMapView
 	releaseall
@@ -41,7 +41,7 @@ NewMauville_Inside_EventScript_15E5C2:: @ 815E5C2
 	lockall
 	setvar VAR_TEMP_1, 0
 	setvar VAR_TEMP_2, 1
-	playse 21
+	playse SE_PIN
 	call NewMauville_Inside_EventScript_15E728
 	special DrawWholeMapView
 	releaseall

--- a/data/scripts/maps/OldaleTown.inc
+++ b/data/scripts/maps/OldaleTown.inc
@@ -43,7 +43,7 @@ OldaleTown_EventScript_14DDBC:: @ 814DDBC
 	checkflag FLAG_TEMP_1
 	goto_if_eq OldaleTown_EventScript_14DE79
 	setflag FLAG_TEMP_1
-	playbgm 420, 0
+	playbgm BGM_TSURETEK, FALSE
 	msgbox OldaleTown_Text_16AEF2, 4
 	closemessage
 	switch FACING

--- a/data/scripts/maps/PacifidlogTown_House3.inc
+++ b/data/scripts/maps/PacifidlogTown_House3.inc
@@ -10,8 +10,8 @@ PacifidlogTown_House3_EventScript_15429E:: @ 815429E
 	copyvar VAR_SPECIAL_4, VAR_SPECIAL_8
 	specialvar RESULT, GetInGameTradeSpeciesInfo
 	copyvar VAR_SPECIAL_9, RESULT
-	msgbox PacifidlogTown_House3_Text_17940E, 5
-	compare RESULT, 0
+	msgbox PacifidlogTown_House3_Text_17940E, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq PacifidlogTown_House3_EventScript_154320
 	special SelectMonForNPCTrade
 	waitstate

--- a/data/scripts/maps/PacifidlogTown_House4.inc
+++ b/data/scripts/maps/PacifidlogTown_House4.inc
@@ -12,10 +12,10 @@ PacifidlogTown_House4_EventScript_154355:: @ 8154355
 PacifidlogTown_House4_EventScript_15435E:: @ 815435E
 	lock
 	faceplayer
-	msgbox PacifidlogTown_House4_Text_17963D, 5
-	compare RESULT, 1
+	msgbox PacifidlogTown_House4_Text_17963D, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq PacifidlogTown_House4_EventScript_15437F
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq PacifidlogTown_House4_EventScript_154389
 	end
 

--- a/data/scripts/maps/PetalburgCity.inc
+++ b/data/scripts/maps/PetalburgCity.inc
@@ -16,7 +16,7 @@ PetalburgCity_EventScript_14B731:: @ 814B731
 	return
 
 PetalburgCity_EventScript_14B739:: @ 814B739
-	savebgm 420
+	savebgm BGM_TSURETEK
 	return
 
 PetalburgCity_MapScript2_14B73D:: @ 814B73D
@@ -181,8 +181,8 @@ PetalburgCity_EventScript_14B85A:: @ 814B85A
 PetalburgCity_EventScript_14B866:: @ 814B866
 	applymovement 9, PetalburgCity_Movement_1A0839
 	waitmovement 0
-	playbgm 420, 0
-	playse 21
+	playbgm BGM_TSURETEK, FALSE
+	playse SE_PIN
 	applymovement 9, PetalburgCity_Movement_1A0833
 	waitmovement 0
 	applymovement 9, PetalburgCity_Movement_1A0835

--- a/data/scripts/maps/PetalburgCity_Gym.inc
+++ b/data/scripts/maps/PetalburgCity_Gym.inc
@@ -84,7 +84,7 @@ PetalburgCity_Gym_EventScript_15456C:: @ 815456C
 	applymovement 255, PetalburgCity_Gym_Movement_1A0845
 	applymovement 10, PetalburgCity_Gym_Movement_1545B4
 	waitmovement 0
-	playse 9
+	playse SE_KAIDAN
 	removeobject 10
 	setflag FLAG_HIDE_WALLY_PETALBURG
 	delay 30
@@ -143,7 +143,7 @@ PetalburgCity_Gym_EventScript_15465E:: @ 815465E
 
 PetalburgCity_Gym_EventScript_154669:: @ 8154669
 	addobject 10
-	playse 8
+	playse SE_DOOR
 	compare VAR_SPECIAL_8, 0
 	call_if 1, PetalburgCity_Gym_EventScript_1547EE
 	compare VAR_SPECIAL_8, 1
@@ -195,7 +195,7 @@ PetalburgCity_Gym_EventScript_154669:: @ 8154669
 	msgbox PetalburgCity_Gym_Text_17A171, 4
 	closemessage
 	setflag FLAG_SPECIAL_FLAG_1
-	playbgm 420, 0
+	playbgm BGM_TSURETEK, FALSE
 	compare VAR_SPECIAL_8, 0
 	call_if 1, PetalburgCity_Gym_EventScript_154835
 	compare VAR_SPECIAL_8, 1

--- a/data/scripts/maps/PetalburgCity_Gym.inc
+++ b/data/scripts/maps/PetalburgCity_Gym.inc
@@ -596,10 +596,10 @@ PetalburgCity_Gym_EventScript_154B73:: @ 8154B73
 	goto_if 0, PetalburgCity_Gym_EventScript_154BB9
 	setvar VAR_SPECIAL_8, 7
 	setvar VAR_SPECIAL_9, 85
-	msgbox PetalburgCity_Gym_Text_17B870, 5
-	compare RESULT, 1
+	msgbox PetalburgCity_Gym_Text_17B870, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq PetalburgCity_Gym_EventScript_154BA8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq PetalburgCity_Gym_EventScript_154BB7
 	end
 
@@ -626,10 +626,10 @@ PetalburgCity_Gym_EventScript_154BC3:: @ 8154BC3
 	goto_if 0, PetalburgCity_Gym_EventScript_154BB9
 	setvar VAR_SPECIAL_8, 1
 	setvar VAR_SPECIAL_9, 98
-	msgbox PetalburgCity_Gym_Text_17B8D4, 5
-	compare RESULT, 1
+	msgbox PetalburgCity_Gym_Text_17B8D4, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq PetalburgCity_Gym_EventScript_154BA8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq PetalburgCity_Gym_EventScript_154BB7
 	end
 
@@ -639,10 +639,10 @@ PetalburgCity_Gym_EventScript_154BF8:: @ 8154BF8
 	goto_if 0, PetalburgCity_Gym_EventScript_154BB9
 	setvar VAR_SPECIAL_8, 7
 	setvar VAR_SPECIAL_9, 46
-	msgbox PetalburgCity_Gym_Text_17B90F, 5
-	compare RESULT, 1
+	msgbox PetalburgCity_Gym_Text_17B90F, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq PetalburgCity_Gym_EventScript_154BA8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq PetalburgCity_Gym_EventScript_154BB7
 	end
 
@@ -652,10 +652,10 @@ PetalburgCity_Gym_EventScript_154C2B:: @ 8154C2B
 	goto_if 0, PetalburgCity_Gym_EventScript_154BB9
 	setvar VAR_SPECIAL_8, 1
 	setvar VAR_SPECIAL_9, 59
-	msgbox PetalburgCity_Gym_Text_17B950, 5
-	compare RESULT, 1
+	msgbox PetalburgCity_Gym_Text_17B950, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq PetalburgCity_Gym_EventScript_154BA8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq PetalburgCity_Gym_EventScript_154BB7
 	end
 
@@ -665,10 +665,10 @@ PetalburgCity_Gym_EventScript_154C5E:: @ 8154C5E
 	goto_if 0, PetalburgCity_Gym_EventScript_154BB9
 	setvar VAR_SPECIAL_8, 7
 	setvar VAR_SPECIAL_9, 59
-	msgbox PetalburgCity_Gym_Text_17B950, 5
-	compare RESULT, 1
+	msgbox PetalburgCity_Gym_Text_17B950, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq PetalburgCity_Gym_EventScript_154BA8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq PetalburgCity_Gym_EventScript_154BB7
 	end
 
@@ -678,10 +678,10 @@ PetalburgCity_Gym_EventScript_154C91:: @ 8154C91
 	goto_if 0, PetalburgCity_Gym_EventScript_154BB9
 	setvar VAR_SPECIAL_8, 1
 	setvar VAR_SPECIAL_9, 72
-	msgbox PetalburgCity_Gym_Text_17B98A, 5
-	compare RESULT, 1
+	msgbox PetalburgCity_Gym_Text_17B98A, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq PetalburgCity_Gym_EventScript_154BA8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq PetalburgCity_Gym_EventScript_154BB7
 	end
 
@@ -691,10 +691,10 @@ PetalburgCity_Gym_EventScript_154CC4:: @ 8154CC4
 	goto_if 0, PetalburgCity_Gym_EventScript_154BB9
 	setvar VAR_SPECIAL_8, 1
 	setvar VAR_SPECIAL_9, 20
-	msgbox PetalburgCity_Gym_Text_17B9C5, 5
-	compare RESULT, 1
+	msgbox PetalburgCity_Gym_Text_17B9C5, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq PetalburgCity_Gym_EventScript_154BA8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq PetalburgCity_Gym_EventScript_154BB7
 	end
 
@@ -704,10 +704,10 @@ PetalburgCity_Gym_EventScript_154CF7:: @ 8154CF7
 	goto_if 0, PetalburgCity_Gym_EventScript_154BB9
 	setvar VAR_SPECIAL_8, 7
 	setvar VAR_SPECIAL_9, 20
-	msgbox PetalburgCity_Gym_Text_17B9C5, 5
-	compare RESULT, 1
+	msgbox PetalburgCity_Gym_Text_17B9C5, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq PetalburgCity_Gym_EventScript_154BA8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq PetalburgCity_Gym_EventScript_154BB7
 	end
 
@@ -717,10 +717,10 @@ PetalburgCity_Gym_EventScript_154D2A:: @ 8154D2A
 	goto_if 0, PetalburgCity_Gym_EventScript_154BB9
 	setvar VAR_SPECIAL_8, 1
 	setvar VAR_SPECIAL_9, 33
-	msgbox PetalburgCity_Gym_Text_17BA00, 5
-	compare RESULT, 1
+	msgbox PetalburgCity_Gym_Text_17BA00, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq PetalburgCity_Gym_EventScript_154BA8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq PetalburgCity_Gym_EventScript_154BB7
 	end
 
@@ -730,10 +730,10 @@ PetalburgCity_Gym_EventScript_154D5D:: @ 8154D5D
 	goto_if 0, PetalburgCity_Gym_EventScript_154BB9
 	setvar VAR_SPECIAL_8, 7
 	setvar VAR_SPECIAL_9, 33
-	msgbox PetalburgCity_Gym_Text_17BA00, 5
-	compare RESULT, 1
+	msgbox PetalburgCity_Gym_Text_17BA00, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq PetalburgCity_Gym_EventScript_154BA8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq PetalburgCity_Gym_EventScript_154BB7
 	end
 
@@ -743,10 +743,10 @@ PetalburgCity_Gym_EventScript_154D90:: @ 8154D90
 	goto_if 0, PetalburgCity_Gym_EventScript_154BB9
 	setvar VAR_SPECIAL_8, 1
 	setvar VAR_SPECIAL_9, 7
-	msgbox PetalburgCity_Gym_Text_17BA3D, 5
-	compare RESULT, 1
+	msgbox PetalburgCity_Gym_Text_17BA3D, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq PetalburgCity_Gym_EventScript_154BA8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq PetalburgCity_Gym_EventScript_154BB7
 	end
 
@@ -756,10 +756,10 @@ PetalburgCity_Gym_EventScript_154DC3:: @ 8154DC3
 	goto_if 0, PetalburgCity_Gym_EventScript_154BB9
 	setvar VAR_SPECIAL_8, 7
 	setvar VAR_SPECIAL_9, 7
-	msgbox PetalburgCity_Gym_Text_17BA3D, 5
-	compare RESULT, 1
+	msgbox PetalburgCity_Gym_Text_17BA3D, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq PetalburgCity_Gym_EventScript_154BA8
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq PetalburgCity_Gym_EventScript_154BB7
 	end
 

--- a/data/scripts/maps/PetalburgWoods.inc
+++ b/data/scripts/maps/PetalburgWoods.inc
@@ -13,7 +13,7 @@ PetalburgWoods_EventScript_15CCA8:: @ 815CCA8
 	waitmovement 0
 	msgbox PetalburgWoods_Text_194D92, 4
 	closemessage
-	playbgm BGM_EVIL_TEAM, 0
+	playbgm BGM_EVIL_TEAM, FALSE
 	applymovement 3, PetalburgWoods_Movement_15CEC3
 	waitmovement 0
 	msgbox PetalburgWoods_Text_194DED, 4
@@ -48,7 +48,7 @@ PetalburgWoods_EventScript_15CD42:: @ 815CD42
 	waitmovement 0
 	msgbox PetalburgWoods_Text_194D92, 4
 	closemessage
-	playbgm BGM_EVIL_TEAM, 0
+	playbgm BGM_EVIL_TEAM, FALSE
 	applymovement 3, PetalburgWoods_Movement_15CEC3
 	waitmovement 0
 	msgbox PetalburgWoods_Text_194DED, 4

--- a/data/scripts/maps/Route101.inc
+++ b/data/scripts/maps/Route101.inc
@@ -18,7 +18,7 @@ Route101_EventScript_14E93F:: @ 814E93F
 
 Route101_EventScript_14E948:: @ 814E948
 	lockall
-	playbgm 410, 1
+	playbgm BGM_EVENT0, TRUE
 	msgbox Route101_Text_16D10E, 4
 	closemessage
 	setobjectxy 2, 0, 15

--- a/data/scripts/maps/Route103.inc
+++ b/data/scripts/maps/Route103.inc
@@ -18,7 +18,7 @@ Route103_EventScript_14EB92:: @ 814EB92
 
 Route103_EventScript_14EBAB:: @ 814EBAB
 	msgbox Route103_Text_16D57A, 4
-	playbgm 415, 1
+	playbgm BGM_GIRL_SUP, TRUE
 	applymovement 2, Route103_Movement_1A0839
 	waitmovement 0
 	applymovement 2, Route103_Movement_1A0833
@@ -34,7 +34,7 @@ Route103_EventScript_14EBAB:: @ 814EBAB
 
 Route103_EventScript_14EC04:: @ 814EC04
 	msgbox Route103_Text_16D762, 4
-	playbgm 421, 1
+	playbgm BGM_BOY_SUP, TRUE
 	applymovement 2, Route103_Movement_1A0839
 	waitmovement 0
 	applymovement 2, Route103_Movement_1A0833
@@ -100,7 +100,7 @@ Route103_EventScript_14ECD9:: @ 814ECD9
 Route103_EventScript_14ED0C:: @ 814ED0C
 	applymovement 2, Route103_Movement_14ED67
 	waitmovement 0
-	playse 10
+	playse SE_DANSA
 	applymovement 2, Route103_Movement_14ED6B
 	waitmovement 0
 	goto Route103_EventScript_14ED46
@@ -109,7 +109,7 @@ Route103_EventScript_14ED0C:: @ 814ED0C
 Route103_EventScript_14ED29:: @ 814ED29
 	applymovement 2, Route103_Movement_14ED71
 	waitmovement 0
-	playse 10
+	playse SE_DANSA
 	applymovement 2, Route103_Movement_14ED74
 	waitmovement 0
 	goto Route103_EventScript_14ED46

--- a/data/scripts/maps/Route104_MrBrineysHouse.inc
+++ b/data/scripts/maps/Route104_MrBrineysHouse.inc
@@ -36,8 +36,8 @@ Route104_MrBrineysHouse_EventScript_15BCEB:: @ 815BCEB
 Route104_MrBrineysHouse_EventScript_15BD0E:: @ 815BD0E
 	setflag FLAG_MR_BRINEY_SAILING_INTRO
 	msgbox Route104_MrBrineysHouse_Text_191A82, 4
-	msgbox Route104_MrBrineysHouse_Text_191AAD, 5
-	compare RESULT, 0
+	msgbox Route104_MrBrineysHouse_Text_191AAD, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route104_MrBrineysHouse_EventScript_15BD97
 	goto Route104_MrBrineysHouse_EventScript_15BDAB
 	end
@@ -53,15 +53,15 @@ Route104_MrBrineysHouse_EventScript_15BD32:: @ 815BD32
 	end
 
 Route104_MrBrineysHouse_EventScript_15BD65:: @ 815BD65
-	msgbox Route104_MrBrineysHouse_Text_191CC3, 5
-	compare RESULT, 0
+	msgbox Route104_MrBrineysHouse_Text_191CC3, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route104_MrBrineysHouse_EventScript_15BD97
 	goto Route104_MrBrineysHouse_EventScript_15BDAB
 	end
 
 Route104_MrBrineysHouse_EventScript_15BD7E:: @ 815BD7E
-	msgbox Route104_MrBrineysHouse_Text_191DA6, 5
-	compare RESULT, 0
+	msgbox Route104_MrBrineysHouse_Text_191DA6, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route104_MrBrineysHouse_EventScript_15BD97
 	goto Route104_MrBrineysHouse_EventScript_15BDAB
 	end

--- a/data/scripts/maps/Route104_PrettyPetalFlowerShop.inc
+++ b/data/scripts/maps/Route104_PrettyPetalFlowerShop.inc
@@ -24,19 +24,19 @@ Route104_PrettyPetalFlowerShop_EventScript_15BE0B:: @ 815BE0B
 	checkflag FLAG_MET_PRETTY_PETAL_SHOP_OWNER
 	goto_if_eq Route104_PrettyPetalFlowerShop_EventScript_15BE4A
 	setflag FLAG_MET_PRETTY_PETAL_SHOP_OWNER
-	msgbox Route104_PrettyPetalFlowerShop_Text_1C5F48, 5
-	compare RESULT, 1
+	msgbox Route104_PrettyPetalFlowerShop_Text_1C5F48, MSGBOX_YESNO
+	compare RESULT, YES
 	call_if 1, Route104_PrettyPetalFlowerShop_EventScript_15BE6A
-	compare RESULT, 0
+	compare RESULT, NO
 	call_if 1, Route104_PrettyPetalFlowerShop_EventScript_15BE73
 	release
 	end
 
 Route104_PrettyPetalFlowerShop_EventScript_15BE4A:: @ 815BE4A
-	msgbox Route104_PrettyPetalFlowerShop_Text_1C5F1B, 5
-	compare RESULT, 1
+	msgbox Route104_PrettyPetalFlowerShop_Text_1C5F1B, MSGBOX_YESNO
+	compare RESULT, YES
 	call_if 1, Route104_PrettyPetalFlowerShop_EventScript_15BE6A
-	compare RESULT, 0
+	compare RESULT, NO
 	call_if 1, Route104_PrettyPetalFlowerShop_EventScript_15BE73
 	release
 	end

--- a/data/scripts/maps/Route109.inc
+++ b/data/scripts/maps/Route109.inc
@@ -278,8 +278,8 @@ Route109_EventScript_14F680:: @ 814F680
 
 Route109_EventScript_14F691:: @ 814F691
 	message Route109_Text_16E0F9
-	msgbox Route109_Text_16E0F9, 5
-	compare RESULT, 0
+	msgbox Route109_Text_16E0F9, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route109_EventScript_14F6F1
 	goto Route109_EventScript_14F6E2
 	end

--- a/data/scripts/maps/Route109_SeashoreHouse.inc
+++ b/data/scripts/maps/Route109_SeashoreHouse.inc
@@ -42,8 +42,8 @@ Route109_SeashoreHouse_EventScript_160E2C:: @ 8160E2C
 Route109_SeashoreHouse_EventScript_160E36:: @ 8160E36
 	showmoneybox 0, 0
 	nop
-	msgbox Route109_SeashoreHouse_Text_19B702, 5
-	compare RESULT, 1
+	msgbox Route109_SeashoreHouse_Text_19B702, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route109_SeashoreHouse_EventScript_160E5A
 	msgbox Route109_SeashoreHouse_Text_19B773, 4
 	hidemoneybox 0, 0

--- a/data/scripts/maps/Route110.inc
+++ b/data/scripts/maps/Route110.inc
@@ -17,7 +17,7 @@ Route110_MapScript1_14F914:: @ 814F914
 	end
 
 Route110_EventScript_14F92F:: @ 814F92F
-	savebgm 403 @ Bicycle music
+	savebgm BGM_CYCLING
 	return
 
 Route110_MapScript2_14F933:: @ 814F933
@@ -352,11 +352,11 @@ Route110_EventScript_14FD34:: @ 814FD34
 	end
 
 Route110_EventScript_14FDA7:: @ 814FDA7
-	playbgm 415, 1
+	playbgm BGM_GIRL_SUP, TRUE
 	return
 
 Route110_EventScript_14FDAC:: @ 814FDAC
-	playbgm 421, 1
+	playbgm BGM_BOY_SUP, TRUE
 	return
 
 Route110_EventScript_14FDB1:: @ 814FDB1

--- a/data/scripts/maps/Route110_TrickHouseEnd.inc
+++ b/data/scripts/maps/Route110_TrickHouseEnd.inc
@@ -167,9 +167,9 @@ Route110_TrickHouseEnd_EventScript_161BAF:: @ 8161BAF
 	msgbox Route110_TrickHouseEnd_Text_19C691, 4
 	setvar VAR_TRICK_HOUSE_PRIZE_PICKUP, 0
 	.ifdef SAPPHIRE
-	givedecoration_std 32
+	givedecoration_std DECOR_BLUE_TENT
 	.else
-	givedecoration_std 31
+	givedecoration_std DECOR_RED_TENT
 	.endc
 	compare RESULT, 0
 	call_if 1, Route110_TrickHouseEnd_EventScript_161C61

--- a/data/scripts/maps/Route110_TrickHouseEnd.inc
+++ b/data/scripts/maps/Route110_TrickHouseEnd.inc
@@ -182,7 +182,7 @@ Route110_TrickHouseEnd_EventScript_161BAF:: @ 8161BAF
 Route110_TrickHouseEnd_EventScript_161C2E:: @ 8161C2E
 	applymovement 1, Route110_TrickHouseEnd_Movement_161315
 	waitmovement 0
-	playse 178
+	playse SE_W153
 	applymovement 1, Route110_TrickHouseEnd_Movement_16131E
 	waitmovement 0
 	removeobject 1
@@ -224,13 +224,13 @@ Route110_TrickHouseEnd_EventScript_161C95:: @ 8161C95
 Route110_TrickHouseEnd_EventScript_161CA0:: @ 8161CA0
 	lockall
 	turnobject 1, 3
-	playse 21
+	playse SE_PIN
 	applymovement 1, Route110_TrickHouseEnd_Movement_1A0833
 	waitmovement 0
 	delay 20
 	applymovement 1, Route110_TrickHouseEnd_Movement_161CEA
 	waitmovement 0
-	playse 178
+	playse SE_W153
 	applymovement 255, Route110_TrickHouseEnd_Movement_1A0845
 	waitmovement 0
 	msgbox Route110_TrickHouseEnd_Text_19CA8B, 4

--- a/data/scripts/maps/Route110_TrickHouseEntrance.inc
+++ b/data/scripts/maps/Route110_TrickHouseEntrance.inc
@@ -450,9 +450,9 @@ Route110_TrickHouseEntrance_EventScript_161518:: @ 8161518
 	waitmovement 0
 	msgbox Route110_TrickHouseEntrance_Text_19C128, 4
 	.ifdef SAPPHIRE
-	givedecoration_std 32
+	givedecoration_std DECOR_BLUE_TENT
 	.else
-	givedecoration_std 31
+	givedecoration_std DECOR_RED_TENT
 	.endif
 	compare RESULT, 1
 	goto_if_eq Route110_TrickHouseEntrance_EventScript_161551

--- a/data/scripts/maps/Route110_TrickHouseEntrance.inc
+++ b/data/scripts/maps/Route110_TrickHouseEntrance.inc
@@ -220,7 +220,7 @@ Route110_TrickHouseEntrance_EventScript_1611D7:: @ 81611D7
 	delay 20
 	applymovement 1, Route110_TrickHouseEntrance_Movement_161315
 	waitmovement 0
-	playse 178
+	playse SE_W153
 	applymovement 1, Route110_TrickHouseEntrance_Movement_16131E
 	waitmovement 0
 	removeobject 1
@@ -243,7 +243,7 @@ Route110_TrickHouseEntrance_EventScript_16121A:: @ 816121A
 	end
 
 Route110_TrickHouseEntrance_EventScript_16124D:: @ 816124D
-	playse 21
+	playse SE_PIN
 	applymovement 255, Route110_TrickHouseEntrance_Movement_1A0833
 	waitmovement 0
 	applymovement 255, Route110_TrickHouseEntrance_Movement_1A0835
@@ -336,7 +336,7 @@ Route110_TrickHouseEntrance_EventScript_161330:: @ 8161330
 	closemessage
 	applymovement 1, Route110_TrickHouseEntrance_Movement_1A0839
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 1, Route110_TrickHouseEntrance_Movement_1A0833
 	waitmovement 0
 	applymovement 1, Route110_TrickHouseEntrance_Movement_1A0835
@@ -469,7 +469,7 @@ Route110_TrickHouseEntrance_EventScript_161551:: @ 8161551
 	waitmovement 0
 	applymovement 1, Route110_TrickHouseEntrance_Movement_161315
 	waitmovement 0
-	playse 178
+	playse SE_W153
 	applymovement 1, Route110_TrickHouseEntrance_Movement_16131E
 	waitmovement 0
 	removeobject 1
@@ -714,7 +714,7 @@ Route110_TrickHousePuzzle5_EventScript_16189C:: @ 816189C
 Route110_TrickHousePuzzle6_EventScript_16189C:: @ 816189C
 Route110_TrickHousePuzzle7_EventScript_16189C:: @ 816189C
 Route110_TrickHousePuzzle8_EventScript_16189C:: @ 816189C
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	message Route110_TrickHousePuzzle1_Text_19C1B8
 	waitfanfare
 	waitmessage

--- a/data/scripts/maps/Route110_TrickHouseEntrance.inc
+++ b/data/scripts/maps/Route110_TrickHouseEntrance.inc
@@ -493,9 +493,9 @@ Route110_TrickHouseEntrance_EventScript_1615BD:: @ 81615BD
 	end
 
 Route110_TrickHouseEntrance_EventScript_1615C7:: @ 81615C7
-	msgbox Route110_TrickHouseEntrance_Text_19BE7D, 5
+	msgbox Route110_TrickHouseEntrance_Text_19BE7D, MSGBOX_YESNO
 	closemessage
-	compare RESULT, 1
+	compare RESULT, YES
 	goto_if_eq Route110_TrickHouseEntrance_EventScript_1615DD
 	releaseall
 	end

--- a/data/scripts/maps/Route110_TrickHousePuzzle2.inc
+++ b/data/scripts/maps/Route110_TrickHousePuzzle2.inc
@@ -36,7 +36,7 @@ Route110_TrickHousePuzzle2_EventScript_161DD5:: @ 8161DD5
 Route110_TrickHousePuzzle2_EventScript_161DE0:: @ 8161DE0
 	lockall
 	setvar VAR_TEMP_1, 1
-	playse 21
+	playse SE_PIN
 	call Route110_TrickHousePuzzle2_EventScript_161E2C
 	special DrawWholeMapView
 	releaseall
@@ -45,7 +45,7 @@ Route110_TrickHousePuzzle2_EventScript_161DE0:: @ 8161DE0
 Route110_TrickHousePuzzle2_EventScript_161DF3:: @ 8161DF3
 	lockall
 	setvar VAR_TEMP_2, 1
-	playse 21
+	playse SE_PIN
 	call Route110_TrickHousePuzzle2_EventScript_161E3F
 	special DrawWholeMapView
 	releaseall
@@ -54,7 +54,7 @@ Route110_TrickHousePuzzle2_EventScript_161DF3:: @ 8161DF3
 Route110_TrickHousePuzzle2_EventScript_161E06:: @ 8161E06
 	lockall
 	setvar VAR_TEMP_3, 1
-	playse 21
+	playse SE_PIN
 	call Route110_TrickHousePuzzle2_EventScript_161E52
 	special DrawWholeMapView
 	releaseall
@@ -63,7 +63,7 @@ Route110_TrickHousePuzzle2_EventScript_161E06:: @ 8161E06
 Route110_TrickHousePuzzle2_EventScript_161E19:: @ 8161E19
 	lockall
 	setvar VAR_TEMP_4, 1
-	playse 21
+	playse SE_PIN
 	call Route110_TrickHousePuzzle2_EventScript_161E65
 	special DrawWholeMapView
 	releaseall

--- a/data/scripts/maps/Route110_TrickHousePuzzle3.inc
+++ b/data/scripts/maps/Route110_TrickHousePuzzle3.inc
@@ -289,7 +289,7 @@ Route110_TrickHousePuzzle3_EventScript_1625F3:: @ 81625F3
 
 Route110_TrickHousePuzzle3_EventScript_1625FF:: @ 81625FF
 	call Route110_TrickHousePuzzle3_EventScript_162612
-	playse 21
+	playse SE_PIN
 	call Route110_TrickHousePuzzle3_EventScript_161F12
 	goto Route110_TrickHousePuzzle3_EventScript_1626AD
 	end

--- a/data/scripts/maps/Route110_TrickHousePuzzle5.inc
+++ b/data/scripts/maps/Route110_TrickHousePuzzle5.inc
@@ -160,7 +160,7 @@ Route110_TrickHousePuzzle5_EventScript_162933:: @ 8162933
 Route110_TrickHousePuzzle5_EventScript_16293F:: @ 816293F
 	setvar VAR_TEMP_1, 1
 	setvar VAR_TEMP_8, 1
-	playse 21
+	playse SE_PIN
 	applymovement 1, Route110_TrickHousePuzzle5_Movement_1A0833
 	waitmovement 0
 	applymovement 1, Route110_TrickHousePuzzle5_Movement_1A0835
@@ -182,7 +182,7 @@ Route110_TrickHousePuzzle5_EventScript_16293F:: @ 816293F
 Route110_TrickHousePuzzle5_EventScript_1629B3:: @ 81629B3
 	setvar VAR_TEMP_2, 1
 	setvar VAR_TEMP_8, 2
-	playse 21
+	playse SE_PIN
 	applymovement 2, Route110_TrickHousePuzzle5_Movement_1A0833
 	waitmovement 0
 	applymovement 2, Route110_TrickHousePuzzle5_Movement_1A0835
@@ -204,7 +204,7 @@ Route110_TrickHousePuzzle5_EventScript_1629B3:: @ 81629B3
 Route110_TrickHousePuzzle5_EventScript_162A27:: @ 8162A27
 	setvar VAR_TEMP_3, 1
 	setvar VAR_TEMP_8, 3
-	playse 21
+	playse SE_PIN
 	applymovement 3, Route110_TrickHousePuzzle5_Movement_1A0833
 	waitmovement 0
 	applymovement 3, Route110_TrickHousePuzzle5_Movement_1A0835
@@ -226,7 +226,7 @@ Route110_TrickHousePuzzle5_EventScript_162A27:: @ 8162A27
 Route110_TrickHousePuzzle5_EventScript_162A9B:: @ 8162A9B
 	setvar VAR_TEMP_4, 1
 	setvar VAR_TEMP_8, 4
-	playse 21
+	playse SE_PIN
 	applymovement 4, Route110_TrickHousePuzzle5_Movement_1A0833
 	waitmovement 0
 	applymovement 4, Route110_TrickHousePuzzle5_Movement_1A0835
@@ -248,7 +248,7 @@ Route110_TrickHousePuzzle5_EventScript_162A9B:: @ 8162A9B
 Route110_TrickHousePuzzle5_EventScript_162B0F:: @ 8162B0F
 	setvar VAR_TEMP_5, 1
 	setvar VAR_TEMP_8, 5
-	playse 21
+	playse SE_PIN
 	applymovement 5, Route110_TrickHousePuzzle5_Movement_1A0833
 	waitmovement 0
 	applymovement 5, Route110_TrickHousePuzzle5_Movement_1A0835
@@ -389,7 +389,7 @@ Route110_TrickHousePuzzle5_EventScript_162D6D:: @ 8162D6D
 
 Route110_TrickHousePuzzle5_EventScript_162D90:: @ 8162D90
 	waitse
-	playse 32
+	playse SE_HAZURE
 	msgbox Route110_TrickHousePuzzle5_Text_19D5CF, 4
 	applymovement 1, Route110_TrickHousePuzzle5_Movement_16309F
 	applymovement 2, Route110_TrickHousePuzzle5_Movement_16309F
@@ -408,7 +408,7 @@ Route110_TrickHousePuzzle5_EventScript_162D90:: @ 8162D90
 
 Route110_TrickHousePuzzle5_EventScript_162DDF:: @ 8162DDF
 	waitse
-	playse 31
+	playse SE_SEIKAI
 	goto Route110_TrickHousePuzzle5_EventScript_162DE9
 	end
 

--- a/data/scripts/maps/Route110_TrickHousePuzzle7.inc
+++ b/data/scripts/maps/Route110_TrickHousePuzzle7.inc
@@ -126,7 +126,7 @@ Route110_TrickHousePuzzle7_EventScript_1632B9:: @ 81632B9
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_1
 	call_if 1, Route110_TrickHousePuzzle7_EventScript_1631F4
 	special DrawWholeMapView
-	playse 36
+	playse SE_TK_KASYA
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_1
 	goto_if 0, Route110_TrickHousePuzzle7_EventScript_1633A4
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_1
@@ -141,7 +141,7 @@ Route110_TrickHousePuzzle7_EventScript_1632E8:: @ 81632E8
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_2
 	call_if 1, Route110_TrickHousePuzzle7_EventScript_163207
 	special DrawWholeMapView
-	playse 36
+	playse SE_TK_KASYA
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_2
 	goto_if 0, Route110_TrickHousePuzzle7_EventScript_1633AE
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_2
@@ -156,7 +156,7 @@ Route110_TrickHousePuzzle7_EventScript_163317:: @ 8163317
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_3
 	call_if 1, Route110_TrickHousePuzzle7_EventScript_16321A
 	special DrawWholeMapView
-	playse 36
+	playse SE_TK_KASYA
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_3
 	goto_if 0, Route110_TrickHousePuzzle7_EventScript_1633B8
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_3
@@ -171,7 +171,7 @@ Route110_TrickHousePuzzle7_EventScript_163346:: @ 8163346
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_4
 	call_if 1, Route110_TrickHousePuzzle7_EventScript_16322D
 	special DrawWholeMapView
-	playse 36
+	playse SE_TK_KASYA
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_4
 	goto_if 0, Route110_TrickHousePuzzle7_EventScript_1633C2
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_4
@@ -186,7 +186,7 @@ Route110_TrickHousePuzzle7_EventScript_163375:: @ 8163375
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_5
 	call_if 1, Route110_TrickHousePuzzle7_EventScript_163240
 	special DrawWholeMapView
-	playse 36
+	playse SE_TK_KASYA
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_5
 	goto_if 0, Route110_TrickHousePuzzle7_EventScript_1633CC
 	checkflag FLAG_TRICK_HOUSE_PUZZLE_7_SWITCH_5

--- a/data/scripts/maps/Route111.inc
+++ b/data/scripts/maps/Route111.inc
@@ -222,14 +222,14 @@ Route111_Movement_1501BA:: @ 81501BA
 
 Route111_EventScript_1501BC:: @ 81501BC
 	setweather 2
-	fadenewbgm 360
+	fadenewbgm BGM_DOORO_X1
 	doweather
 	setvar VAR_TEMP_3, 0
 	end
 
 Route111_EventScript_1501C9:: @ 81501C9
 	setweather 8
-	fadenewbgm 409
+	fadenewbgm BGM_ASHROAD
 	doweather
 	end
 

--- a/data/scripts/maps/Route111.inc
+++ b/data/scripts/maps/Route111.inc
@@ -51,8 +51,8 @@ Route111_EventScript_15000D:: @ 815000D
 
 Route111_EventScript_150023:: @ 8150023
 	lockall
-	msgbox Route111_Text_16FA54, 5
-	compare RESULT, 0
+	msgbox Route111_Text_16FA54, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route111_EventScript_15005F
 	giveitem_std ITEM_ROOT_FOSSIL
 	closemessage
@@ -73,8 +73,8 @@ Route111_EventScript_15005F:: @ 815005F
 
 Route111_EventScript_150069:: @ 8150069
 	lockall
-	msgbox Route111_Text_16FAED, 5
-	compare RESULT, 0
+	msgbox Route111_Text_16FAED, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route111_EventScript_1500A5
 	giveitem_std ITEM_CLAW_FOSSIL
 	closemessage
@@ -237,8 +237,8 @@ Route111_EventScript_1501D1:: @ 81501D1
 	lock
 	faceplayer
 	setflag FLAG_LANDMARK_WINSTRATE_FAMILY
-	msgbox Route111_Text_16F705, 5
-	compare RESULT, 1
+	msgbox Route111_Text_16F705, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route111_EventScript_1501F3
 	msgbox Route111_Text_16F785, 4
 	release

--- a/data/scripts/maps/Route111.inc
+++ b/data/scripts/maps/Route111.inc
@@ -34,7 +34,7 @@ Route111_EventScript_14FFCD:: @ 814FFCD
 	goto_if 0, Route111_EventScript_15000C
 
 Route111_EventScript_150009:: @ 8150009
-	setweather 8
+	setweather WEATHER_SANDSTORM
 
 Route111_EventScript_15000C:: @ 815000C
 	return
@@ -221,14 +221,14 @@ Route111_Movement_1501BA:: @ 81501BA
 	step_end
 
 Route111_EventScript_1501BC:: @ 81501BC
-	setweather 2
+	setweather WEATHER_SUNNY
 	fadenewbgm BGM_DOORO_X1
 	doweather
 	setvar VAR_TEMP_3, 0
 	end
 
 Route111_EventScript_1501C9:: @ 81501C9
-	setweather 8
+	setweather WEATHER_SANDSTORM
 	fadenewbgm BGM_ASHROAD
 	doweather
 	end

--- a/data/scripts/maps/Route111_OldLadysRestStop.inc
+++ b/data/scripts/maps/Route111_OldLadysRestStop.inc
@@ -9,10 +9,10 @@ Route111_OldLadysRestStop_MapScript1_15BFD7:: @ 815BFD7
 Route111_OldLadysRestStop_EventScript_15BFDB:: @ 815BFDB
 	lock
 	faceplayer
-	msgbox Route111_OldLadysRestStop_Text_1923AF, 5
-	compare RESULT, 1
+	msgbox Route111_OldLadysRestStop_Text_1923AF, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route111_OldLadysRestStop_EventScript_15BFFC
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq Route111_OldLadysRestStop_EventScript_15C029
 	end
 
@@ -20,10 +20,10 @@ Route111_OldLadysRestStop_EventScript_15BFFC:: @ 815BFFC
 	msgbox Route111_OldLadysRestStop_Text_192423, 4
 	closemessage
 	call Route111_OldLadysRestStop_EventScript_1A02CA
-	msgbox Route111_OldLadysRestStop_Text_19244D, 5
-	compare RESULT, 1
+	msgbox Route111_OldLadysRestStop_Text_19244D, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route111_OldLadysRestStop_EventScript_15BFFC
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq Route111_OldLadysRestStop_EventScript_15C029
 	end
 

--- a/data/scripts/maps/Route112_CableCarStation.inc
+++ b/data/scripts/maps/Route112_CableCarStation.inc
@@ -32,10 +32,10 @@ Route112_CableCarStation_EventScript_15C068:: @ 815C068
 Route112_CableCarStation_EventScript_15C08C:: @ 815C08C
 	lock
 	faceplayer
-	msgbox Route112_CableCarStation_Text_1924F5, 5
-	compare RESULT, 1
+	msgbox Route112_CableCarStation_Text_1924F5, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route112_CableCarStation_EventScript_15C0AD
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq Route112_CableCarStation_EventScript_15C0DC
 	end
 

--- a/data/scripts/maps/Route113.inc
+++ b/data/scripts/maps/Route113.inc
@@ -18,7 +18,7 @@ Route113_EventScript_1505E5:: @ 81505E5
 	goto_if 0, Route113_EventScript_150604
 	compare VAR_TEMP_0, 84
 	goto_if 2, Route113_EventScript_150604
-	setweather 7
+	setweather WEATHER_ASH
 	return
 
 Route113_EventScript_150604:: @ 8150604

--- a/data/scripts/maps/Route113_GlassWorkshop.inc
+++ b/data/scripts/maps/Route113_GlassWorkshop.inc
@@ -72,8 +72,8 @@ Route113_GlassWorkshop_EventScript_163660:: @ 8163660
 	setvar VAR_SPECIAL_A, 250
 	compare VAR_ASH_GATHER_COUNT, 250
 	goto_if 0, Route113_GlassWorkshop_EventScript_163830
-	msgbox Route113_GlassWorkshop_Text_19E7CD, 5
-	compare RESULT, 0
+	msgbox Route113_GlassWorkshop_Text_19E7CD, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route113_GlassWorkshop_EventScript_163845
 	setvar VAR_GLASS_WORKSHOP_STATE, 10
 	subvar VAR_ASH_GATHER_COUNT, 250
@@ -86,8 +86,8 @@ Route113_GlassWorkshop_EventScript_16369C:: @ 816369C
 	setvar VAR_SPECIAL_A, 500
 	compare VAR_ASH_GATHER_COUNT, 500
 	goto_if 0, Route113_GlassWorkshop_EventScript_163830
-	msgbox Route113_GlassWorkshop_Text_19E7CD, 5
-	compare RESULT, 0
+	msgbox Route113_GlassWorkshop_Text_19E7CD, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route113_GlassWorkshop_EventScript_163845
 	setvar VAR_GLASS_WORKSHOP_STATE, 11
 	subvar VAR_ASH_GATHER_COUNT, 500
@@ -100,8 +100,8 @@ Route113_GlassWorkshop_EventScript_1636D8:: @ 81636D8
 	setvar VAR_SPECIAL_A, 500
 	compare VAR_ASH_GATHER_COUNT, 500
 	goto_if 0, Route113_GlassWorkshop_EventScript_163830
-	msgbox Route113_GlassWorkshop_Text_19E7CD, 5
-	compare RESULT, 0
+	msgbox Route113_GlassWorkshop_Text_19E7CD, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route113_GlassWorkshop_EventScript_163845
 	setvar VAR_GLASS_WORKSHOP_STATE, 12
 	subvar VAR_ASH_GATHER_COUNT, 500
@@ -114,8 +114,8 @@ Route113_GlassWorkshop_EventScript_163714:: @ 8163714
 	setvar VAR_SPECIAL_A, 1000
 	compare VAR_ASH_GATHER_COUNT, 1000
 	goto_if 0, Route113_GlassWorkshop_EventScript_163830
-	msgbox Route113_GlassWorkshop_Text_19E7CD, 5
-	compare RESULT, 0
+	msgbox Route113_GlassWorkshop_Text_19E7CD, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route113_GlassWorkshop_EventScript_163845
 	setvar VAR_GLASS_WORKSHOP_STATE, 13
 	subvar VAR_ASH_GATHER_COUNT, 1000
@@ -128,8 +128,8 @@ Route113_GlassWorkshop_EventScript_163750:: @ 8163750
 	setvar VAR_SPECIAL_A, 1000
 	compare VAR_ASH_GATHER_COUNT, 1000
 	goto_if 0, Route113_GlassWorkshop_EventScript_163830
-	msgbox Route113_GlassWorkshop_Text_19E7CD, 5
-	compare RESULT, 0
+	msgbox Route113_GlassWorkshop_Text_19E7CD, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route113_GlassWorkshop_EventScript_163845
 	setvar VAR_GLASS_WORKSHOP_STATE, 14
 	subvar VAR_ASH_GATHER_COUNT, 1000
@@ -143,8 +143,8 @@ Route113_GlassWorkshop_EventScript_16378C:: @ 816378C
 	setvar VAR_SPECIAL_A, 6000
 	compare VAR_ASH_GATHER_COUNT, 6000
 	goto_if 0, Route113_GlassWorkshop_EventScript_163830
-	msgbox Route113_GlassWorkshop_Text_19E7CD, 5
-	compare RESULT, 0
+	msgbox Route113_GlassWorkshop_Text_19E7CD, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route113_GlassWorkshop_EventScript_163845
 	setvar VAR_GLASS_WORKSHOP_STATE, 15
 	subvar VAR_ASH_GATHER_COUNT, 6000
@@ -158,8 +158,8 @@ Route113_GlassWorkshop_EventScript_1637CD:: @ 81637CD
 	setvar VAR_SPECIAL_A, 8000
 	compare VAR_ASH_GATHER_COUNT, 8000
 	goto_if 0, Route113_GlassWorkshop_EventScript_163830
-	msgbox Route113_GlassWorkshop_Text_19E7CD, 5
-	compare RESULT, 0
+	msgbox Route113_GlassWorkshop_Text_19E7CD, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route113_GlassWorkshop_EventScript_163845
 	setvar VAR_GLASS_WORKSHOP_STATE, 16
 	subvar VAR_ASH_GATHER_COUNT, 8000

--- a/data/scripts/maps/Route113_GlassWorkshop.inc
+++ b/data/scripts/maps/Route113_GlassWorkshop.inc
@@ -67,7 +67,7 @@ Route113_GlassWorkshop_EventScript_1635EE:: @ 81635EE
 	end
 
 Route113_GlassWorkshop_EventScript_163660:: @ 8163660
-	setvar VAR_SPECIAL_8, 39
+	setvar VAR_SPECIAL_8, ITEM_BLUE_FLUTE
 	bufferitemname 0, VAR_SPECIAL_8
 	setvar VAR_SPECIAL_A, 250
 	compare VAR_ASH_GATHER_COUNT, 250
@@ -81,7 +81,7 @@ Route113_GlassWorkshop_EventScript_163660:: @ 8163660
 	end
 
 Route113_GlassWorkshop_EventScript_16369C:: @ 816369C
-	setvar VAR_SPECIAL_8, 40
+	setvar VAR_SPECIAL_8, ITEM_YELLOW_FLUTE
 	bufferitemname 0, VAR_SPECIAL_8
 	setvar VAR_SPECIAL_A, 500
 	compare VAR_ASH_GATHER_COUNT, 500
@@ -95,7 +95,7 @@ Route113_GlassWorkshop_EventScript_16369C:: @ 816369C
 	end
 
 Route113_GlassWorkshop_EventScript_1636D8:: @ 81636D8
-	setvar VAR_SPECIAL_8, 41
+	setvar VAR_SPECIAL_8, ITEM_RED_FLUTE
 	bufferitemname 0, VAR_SPECIAL_8
 	setvar VAR_SPECIAL_A, 500
 	compare VAR_ASH_GATHER_COUNT, 500
@@ -109,7 +109,7 @@ Route113_GlassWorkshop_EventScript_1636D8:: @ 81636D8
 	end
 
 Route113_GlassWorkshop_EventScript_163714:: @ 8163714
-	setvar VAR_SPECIAL_8, 43
+	setvar VAR_SPECIAL_8, ITEM_WHITE_FLUTE
 	bufferitemname 0, VAR_SPECIAL_8
 	setvar VAR_SPECIAL_A, 1000
 	compare VAR_ASH_GATHER_COUNT, 1000
@@ -123,7 +123,7 @@ Route113_GlassWorkshop_EventScript_163714:: @ 8163714
 	end
 
 Route113_GlassWorkshop_EventScript_163750:: @ 8163750
-	setvar VAR_SPECIAL_8, 42
+	setvar VAR_SPECIAL_8, ITEM_BLACK_FLUTE
 	bufferitemname 0, VAR_SPECIAL_8
 	setvar VAR_SPECIAL_A, 1000
 	compare VAR_ASH_GATHER_COUNT, 1000
@@ -138,7 +138,7 @@ Route113_GlassWorkshop_EventScript_163750:: @ 8163750
 
 Route113_GlassWorkshop_EventScript_16378C:: @ 816378C
 	setvar VAR_SPECIAL_9, 1
-	setvar VAR_SPECIAL_8, 13
+	setvar VAR_SPECIAL_8, DECOR_PRETTY_CHAIR
 	bufferdecorationname 0, VAR_SPECIAL_8
 	setvar VAR_SPECIAL_A, 6000
 	compare VAR_ASH_GATHER_COUNT, 6000
@@ -153,7 +153,7 @@ Route113_GlassWorkshop_EventScript_16378C:: @ 816378C
 
 Route113_GlassWorkshop_EventScript_1637CD:: @ 81637CD
 	setvar VAR_SPECIAL_9, 1
-	setvar VAR_SPECIAL_8, 6
+	setvar VAR_SPECIAL_8, DECOR_PRETTY_DESK
 	bufferdecorationname 0, VAR_SPECIAL_8
 	setvar VAR_SPECIAL_A, 8000
 	compare VAR_ASH_GATHER_COUNT, 8000
@@ -246,50 +246,50 @@ Route113_GlassWorkshop_EventScript_1638D2:: @ 81638D2
 
 Route113_GlassWorkshop_EventScript_163925:: @ 8163925
 	setvar VAR_SPECIAL_9, 0
-	setvar VAR_SPECIAL_8, 39
+	setvar VAR_SPECIAL_8, ITEM_BLUE_FLUTE
 	bufferitemname 0, VAR_SPECIAL_8
 	goto Route113_GlassWorkshop_EventScript_1639B1
 	end
 
 Route113_GlassWorkshop_EventScript_163939:: @ 8163939
 	setvar VAR_SPECIAL_9, 0
-	setvar VAR_SPECIAL_8, 40
+	setvar VAR_SPECIAL_8, ITEM_YELLOW_FLUTE
 	bufferitemname 0, VAR_SPECIAL_8
 	goto Route113_GlassWorkshop_EventScript_1639B1
 	end
 
 Route113_GlassWorkshop_EventScript_16394D:: @ 816394D
 	setvar VAR_SPECIAL_9, 0
-	setvar VAR_SPECIAL_8, 41
+	setvar VAR_SPECIAL_8, ITEM_RED_FLUTE
 	bufferitemname 0, VAR_SPECIAL_8
 	goto Route113_GlassWorkshop_EventScript_1639B1
 	end
 
 Route113_GlassWorkshop_EventScript_163961:: @ 8163961
 	setvar VAR_SPECIAL_9, 0
-	setvar VAR_SPECIAL_8, 43
+	setvar VAR_SPECIAL_8, ITEM_WHITE_FLUTE
 	bufferitemname 0, VAR_SPECIAL_8
 	goto Route113_GlassWorkshop_EventScript_1639B1
 	end
 
 Route113_GlassWorkshop_EventScript_163975:: @ 8163975
 	setvar VAR_SPECIAL_9, 0
-	setvar VAR_SPECIAL_8, 42
+	setvar VAR_SPECIAL_8, ITEM_BLACK_FLUTE
 	bufferitemname 0, VAR_SPECIAL_8
 	goto Route113_GlassWorkshop_EventScript_1639B1
 	end
 
 Route113_GlassWorkshop_EventScript_163989:: @ 8163989
 	setvar VAR_SPECIAL_9, 1
-	setvar VAR_SPECIAL_8, 13
-	bufferdecorationname 0, 13
+	setvar VAR_SPECIAL_8, DECOR_PRETTY_CHAIR
+	bufferdecorationname 0, DECOR_PRETTY_CHAIR
 	goto Route113_GlassWorkshop_EventScript_1639B1
 	end
 
 Route113_GlassWorkshop_EventScript_16399D:: @ 816399D
 	setvar VAR_SPECIAL_9, 1
-	setvar VAR_SPECIAL_8, 6
-	bufferdecorationname 0, 6
+	setvar VAR_SPECIAL_8, DECOR_PRETTY_DESK
+	bufferdecorationname 0, DECOR_PRETTY_DESK
 	goto Route113_GlassWorkshop_EventScript_1639B1
 	end
 

--- a/data/scripts/maps/Route113_GlassWorkshop.inc
+++ b/data/scripts/maps/Route113_GlassWorkshop.inc
@@ -197,7 +197,7 @@ Route113_GlassWorkshop_EventScript_163851:: @ 8163851
 	msgbox Route113_GlassWorkshop_Text_19E827, 4
 	closemessage
 	fadescreen 1
-	playse 5
+	playse SE_SELECT
 	delay 30
 	fadescreen 0
 	msgbox Route113_GlassWorkshop_Text_19E9D7, 4

--- a/data/scripts/maps/Route114_LanettesHouse.inc
+++ b/data/scripts/maps/Route114_LanettesHouse.inc
@@ -31,16 +31,16 @@ Route114_LanettesHouse_EventScript_15C28F:: @ 815C28F
 
 Route114_LanettesHouse_EventScript_15C299:: @ 815C299
 	lockall
-	msgbox Route114_LanettesHouse_Text_192B4A, 5
-	compare RESULT, 1
+	msgbox Route114_LanettesHouse_Text_192B4A, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route114_LanettesHouse_EventScript_15C2B7
 	msgbox Route114_LanettesHouse_Text_192DA9, 4
 	releaseall
 	end
 
 Route114_LanettesHouse_EventScript_15C2B7:: @ 815C2B7
-	msgbox Route114_LanettesHouse_Text_192C01, 5
-	compare RESULT, 1
+	msgbox Route114_LanettesHouse_Text_192C01, MSGBOX_YESNO
+	compare RESULT, YES
 	call_if 1, Route114_LanettesHouse_EventScript_15C2CC
 	releaseall
 	end

--- a/data/scripts/maps/Route118.inc
+++ b/data/scripts/maps/Route118.inc
@@ -77,7 +77,7 @@ Route118_EventScript_150FE4:: @ 8150FE4
 	end
 
 Route118_EventScript_151004:: @ 8151004
-	playse 10
+	playse SE_DANSA
 	applymovement 19, Route118_Movement_15106D
 	waitmovement 0
 	delay 30

--- a/data/scripts/maps/Route118.inc
+++ b/data/scripts/maps/Route118.inc
@@ -11,10 +11,10 @@ Route118_EventScript_150F34:: @ 8150F34
 	faceplayer
 	checkflag FLAG_RECEIVED_GOOD_ROD
 	goto_if_eq Route118_EventScript_150F89
-	msgbox Route118_Text_170F12, 5
-	compare RESULT, 1
+	msgbox Route118_Text_170F12, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route118_EventScript_150F5E
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq Route118_EventScript_150F7F
 	end
 

--- a/data/scripts/maps/Route119.inc
+++ b/data/scripts/maps/Route119.inc
@@ -80,11 +80,11 @@ Route119_EventScript_1511DB:: @ 81511DB
 	end
 
 Route119_EventScript_151254:: @ 8151254
-	playbgm 415, 1
+	playbgm BGM_GIRL_SUP, TRUE
 	return
 
 Route119_EventScript_151259:: @ 8151259
-	playbgm 421, 1
+	playbgm BGM_BOY_SUP, TRUE
 	return
 
 Route119_EventScript_15125E:: @ 815125E

--- a/data/scripts/maps/Route119_WeatherInstitute_2F.inc
+++ b/data/scripts/maps/Route119_WeatherInstitute_2F.inc
@@ -58,7 +58,7 @@ Route119_WeatherInstitute_2F_EventScript_163D7A:: @ 8163D7A
 	getpartysize
 	compare RESULT, 6
 	goto_if_eq Route119_WeatherInstitute_2F_EventScript_163DB4
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	message Route119_WeatherInstitute_2F_Text_19F267
 	waitfanfare
 	waitmessage

--- a/data/scripts/maps/Route120.inc
+++ b/data/scripts/maps/Route120.inc
@@ -115,10 +115,10 @@ Route120_EventScript_151739:: @ 8151739
 	dodailyevents
 	checkflag FLAG_DAILY_RECEIVED_BERRY_ROUTE120
 	goto_if_eq Route120_EventScript_151837
-	msgbox Route120_Text_1C58F1, 5
-	compare RESULT, 1
+	msgbox Route120_Text_1C58F1, MSGBOX_YESNO
+	compare RESULT, YES
 	call_if 1, Route120_EventScript_151841
-	compare RESULT, 0
+	compare RESULT, NO
 	call_if 1, Route120_EventScript_15184A
 	specialvar RESULT, GetPlayerTrainerIdOnesDigit
 	switch RESULT
@@ -186,8 +186,8 @@ Route120_EventScript_151853:: @ 8151853
 	faceplayer
 	checkflag FLAG_NOT_READY_FOR_BATTLE_ROUTE120
 	goto_if_eq Route120_EventScript_151884
-	msgbox Route120_Text_171827, 5
-	compare RESULT, 0
+	msgbox Route120_Text_171827, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route120_EventScript_151877
 	goto Route120_EventScript_15189D
 	end
@@ -199,8 +199,8 @@ Route120_EventScript_151877:: @ 8151877
 	end
 
 Route120_EventScript_151884:: @ 8151884
-	msgbox Route120_Text_17196F, 5
-	compare RESULT, 0
+	msgbox Route120_Text_17196F, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route120_EventScript_151877
 	goto Route120_EventScript_15189D
 	end

--- a/data/scripts/maps/Route120.inc
+++ b/data/scripts/maps/Route120.inc
@@ -90,11 +90,11 @@ Route120_EventScript_1516EA:: @ 81516EA
 	return
 
 Route120_EventScript_151711:: @ 8151711
-	setweather 1
+	setweather WEATHER_CLOUDS
 	return
 
 Route120_EventScript_151715:: @ 8151715
-	setweather 2
+	setweather WEATHER_SUNNY
 	return
 
 Route120_EventScript_151719:: @ 8151719
@@ -106,7 +106,7 @@ Route120_EventScript_151719:: @ 8151719
 	end
 
 Route120_EventScript_151735:: @ 8151735
-	setweather 3
+	setweather WEATHER_RAIN_LIGHT
 	return
 
 Route120_EventScript_151739:: @ 8151739

--- a/data/scripts/maps/Route121_SafariZoneEntrance.inc
+++ b/data/scripts/maps/Route121_SafariZoneEntrance.inc
@@ -71,7 +71,7 @@ Route121_SafariZoneEntrance_EventScript_15C3B3:: @ 815C3B3
 	updatemoneybox 0, 0
 	nop
 	msgbox Route121_SafariZoneEntrance_Text_1C38F4, 4
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	message Route121_SafariZoneEntrance_Text_1C3910
 	waitfanfare
 	waitmessage

--- a/data/scripts/maps/Route121_SafariZoneEntrance.inc
+++ b/data/scripts/maps/Route121_SafariZoneEntrance.inc
@@ -33,8 +33,8 @@ Route121_SafariZoneEntrance_EventScript_15C351:: @ 815C351
 Route121_SafariZoneEntrance_EventScript_15C35A:: @ 815C35A
 	lock
 	faceplayer
-	msgbox Route121_SafariZoneEntrance_Text_1C3704, 5
-	compare RESULT, 1
+	msgbox Route121_SafariZoneEntrance_Text_1C3704, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route121_SafariZoneEntrance_EventScript_15C379
 	msgbox Route121_SafariZoneEntrance_Text_1C373C, 4
 	release
@@ -51,8 +51,8 @@ Route121_SafariZoneEntrance_EventScript_15C383:: @ 815C383
 	waitmovement 0
 	showmoneybox 0, 0
 	nop
-	msgbox Route121_SafariZoneEntrance_Text_1C3832, 5
-	compare RESULT, 1
+	msgbox Route121_SafariZoneEntrance_Text_1C3832, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route121_SafariZoneEntrance_EventScript_15C3B3
 	msgbox Route121_SafariZoneEntrance_Text_1C3895, 4
 	goto Route121_SafariZoneEntrance_EventScript_15C46C

--- a/data/scripts/maps/Route124_DivingTreasureHuntersHouse.inc
+++ b/data/scripts/maps/Route124_DivingTreasureHuntersHouse.inc
@@ -224,23 +224,23 @@ Route124_DivingTreasureHuntersHouse_EventScript_16420F:: @ 816420F
 	end
 
 Route124_DivingTreasureHuntersHouse_EventScript_164256:: @ 8164256
-	setvar VAR_SPECIAL_8, 48
-	setvar VAR_SPECIAL_9, 95
+	setvar VAR_SPECIAL_8, ITEM_RED_SHARD
+	setvar VAR_SPECIAL_9, ITEM_FIRE_STONE
 	goto Route124_DivingTreasureHuntersHouse_EventScript_164292
 
 Route124_DivingTreasureHuntersHouse_EventScript_164265:: @ 8164265
-	setvar VAR_SPECIAL_8, 50
-	setvar VAR_SPECIAL_9, 96
+	setvar VAR_SPECIAL_8, ITEM_YELLOW_SHARD
+	setvar VAR_SPECIAL_9, ITEM_THUNDER_STONE
 	goto Route124_DivingTreasureHuntersHouse_EventScript_164292
 
 Route124_DivingTreasureHuntersHouse_EventScript_164274:: @ 8164274
-	setvar VAR_SPECIAL_8, 49
-	setvar VAR_SPECIAL_9, 97
+	setvar VAR_SPECIAL_8, ITEM_BLUE_SHARD
+	setvar VAR_SPECIAL_9, ITEM_WATER_STONE
 	goto Route124_DivingTreasureHuntersHouse_EventScript_164292
 
 Route124_DivingTreasureHuntersHouse_EventScript_164283:: @ 8164283
-	setvar VAR_SPECIAL_8, 51
-	setvar VAR_SPECIAL_9, 98
+	setvar VAR_SPECIAL_8, ITEM_GREEN_SHARD
+	setvar VAR_SPECIAL_9, ITEM_LEAF_STONE
 	goto Route124_DivingTreasureHuntersHouse_EventScript_164292
 
 Route124_DivingTreasureHuntersHouse_EventScript_164292:: @ 8164292

--- a/data/scripts/maps/Route124_DivingTreasureHuntersHouse.inc
+++ b/data/scripts/maps/Route124_DivingTreasureHuntersHouse.inc
@@ -246,8 +246,8 @@ Route124_DivingTreasureHuntersHouse_EventScript_164283:: @ 8164283
 Route124_DivingTreasureHuntersHouse_EventScript_164292:: @ 8164292
 	bufferitemname 0, VAR_SPECIAL_8
 	bufferitemname 1, VAR_SPECIAL_9
-	msgbox Route124_DivingTreasureHuntersHouse_Text_19F5E0, 5
-	compare RESULT, 0
+	msgbox Route124_DivingTreasureHuntersHouse_Text_19F5E0, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq Route124_DivingTreasureHuntersHouse_EventScript_16431F
 	checkitemspace VAR_SPECIAL_9, 1
 	compare RESULT, 1
@@ -265,8 +265,8 @@ Route124_DivingTreasureHuntersHouse_EventScript_1642D3:: @ 81642D3
 	call Route124_DivingTreasureHuntersHouse_EventScript_163E44
 	compare VAR_TEMP_1, 0
 	goto_if_eq Route124_DivingTreasureHuntersHouse_EventScript_164333
-	msgbox Route124_DivingTreasureHuntersHouse_Text_19F629, 5
-	compare RESULT, 1
+	msgbox Route124_DivingTreasureHuntersHouse_Text_19F629, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route124_DivingTreasureHuntersHouse_EventScript_163EB0
 	goto Route124_DivingTreasureHuntersHouse_EventScript_16431F
 	end

--- a/data/scripts/maps/RustboroCity.inc
+++ b/data/scripts/maps/RustboroCity.inc
@@ -381,7 +381,7 @@ RustboroCity_EventScript_14C650:: @ 814C650
 RustboroCity_EventScript_14C691:: @ 814C691
 	applymovement 9, RustboroCity_Movement_1A0841
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 9, RustboroCity_Movement_1A0833
 	waitmovement 0
 	applymovement 9, RustboroCity_Movement_1A0835
@@ -393,7 +393,7 @@ RustboroCity_EventScript_14C691:: @ 814C691
 RustboroCity_EventScript_14C6BD:: @ 814C6BD
 	applymovement 9, RustboroCity_Movement_1A083F
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 9, RustboroCity_Movement_1A0833
 	waitmovement 0
 	applymovement 9, RustboroCity_Movement_1A0835
@@ -405,7 +405,7 @@ RustboroCity_EventScript_14C6BD:: @ 814C6BD
 RustboroCity_EventScript_14C6E9:: @ 814C6E9
 	applymovement 9, RustboroCity_Movement_1A0845
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 9, RustboroCity_Movement_1A0833
 	waitmovement 0
 	applymovement 9, RustboroCity_Movement_1A0835
@@ -417,7 +417,7 @@ RustboroCity_EventScript_14C6E9:: @ 814C6E9
 RustboroCity_EventScript_14C715:: @ 814C715
 	applymovement 9, RustboroCity_Movement_1A0845
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 9, RustboroCity_Movement_1A0833
 	waitmovement 0
 	applymovement 9, RustboroCity_Movement_1A0835
@@ -489,7 +489,7 @@ RustboroCity_EventScript_14C7F5:: @ 814C7F5
 RustboroCity_EventScript_14C7FE:: @ 814C7FE
 	applymovement 9, RustboroCity_Movement_1A0841
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 9, RustboroCity_Movement_1A0833
 	waitmovement 0
 	applymovement 9, RustboroCity_Movement_1A0835
@@ -501,7 +501,7 @@ RustboroCity_EventScript_14C7FE:: @ 814C7FE
 RustboroCity_EventScript_14C82A:: @ 814C82A
 	applymovement 9, RustboroCity_Movement_1A0843
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 9, RustboroCity_Movement_1A0833
 	waitmovement 0
 	applymovement 9, RustboroCity_Movement_1A0835
@@ -513,7 +513,7 @@ RustboroCity_EventScript_14C82A:: @ 814C82A
 RustboroCity_EventScript_14C856:: @ 814C856
 	applymovement 9, RustboroCity_Movement_1A0845
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 9, RustboroCity_Movement_1A0833
 	waitmovement 0
 	applymovement 9, RustboroCity_Movement_1A0835
@@ -525,7 +525,7 @@ RustboroCity_EventScript_14C856:: @ 814C856
 RustboroCity_EventScript_14C882:: @ 814C882
 	applymovement 9, RustboroCity_Movement_1A0845
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 9, RustboroCity_Movement_1A0833
 	waitmovement 0
 	applymovement 9, RustboroCity_Movement_1A0835
@@ -539,7 +539,7 @@ RustboroCity_EventScript_14C882:: @ 814C882
 RustboroCity_EventScript_14C8B8:: @ 814C8B8
 	applymovement 9, RustboroCity_Movement_1A083F
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 9, RustboroCity_Movement_1A0833
 	waitmovement 0
 	applymovement 9, RustboroCity_Movement_1A0835

--- a/data/scripts/maps/RustboroCity_DevonCorp_2F.inc
+++ b/data/scripts/maps/RustboroCity_DevonCorp_2F.inc
@@ -80,7 +80,7 @@ RustboroCity_DevonCorp_2F_EventScript_157564:: @ 8157564
 
 RustboroCity_DevonCorp_2F_EventScript_1575A6:: @ 81575A6
 	closemessage
-	playse 21
+	playse SE_PIN
 	applymovement 5, RustboroCity_DevonCorp_2F_Movement_1A0833
 	waitmovement 0
 	applymovement 5, RustboroCity_DevonCorp_2F_Movement_1A0835
@@ -98,7 +98,7 @@ RustboroCity_DevonCorp_2F_EventScript_1575A6:: @ 81575A6
 
 RustboroCity_DevonCorp_2F_EventScript_1575EE:: @ 81575EE
 	closemessage
-	playse 21
+	playse SE_PIN
 	applymovement 5, RustboroCity_DevonCorp_2F_Movement_1A0833
 	waitmovement 0
 	applymovement 5, RustboroCity_DevonCorp_2F_Movement_1A0835
@@ -140,7 +140,7 @@ RustboroCity_DevonCorp_2F_EventScript_157661:: @ 8157661
 	copyvar VAR_SPECIAL_4, RESULT
 	setvar VAR_FOSSIL_RESURRECTION_STATE, 0
 	setflag FLAG_RECEIVED_FOSSIL_MON
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	message RustboroCity_DevonCorp_2F_Text_18319E
 	waitfanfare
 	waitmessage
@@ -160,7 +160,7 @@ RustboroCity_DevonCorp_2F_EventScript_1576B4:: @ 81576B4
 	copyvar VAR_SPECIAL_4, RESULT
 	setvar VAR_FOSSIL_RESURRECTION_STATE, 0
 	setflag FLAG_RECEIVED_FOSSIL_MON
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	message RustboroCity_DevonCorp_2F_Text_18319E
 	waitfanfare
 	waitmessage

--- a/data/scripts/maps/RustboroCity_DevonCorp_2F.inc
+++ b/data/scripts/maps/RustboroCity_DevonCorp_2F.inc
@@ -85,8 +85,8 @@ RustboroCity_DevonCorp_2F_EventScript_1575A6:: @ 81575A6
 	waitmovement 0
 	applymovement 5, RustboroCity_DevonCorp_2F_Movement_1A0835
 	waitmovement 0
-	msgbox RustboroCity_DevonCorp_2F_Text_182F35, 5
-	compare RESULT, 0
+	msgbox RustboroCity_DevonCorp_2F_Text_182F35, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq RustboroCity_DevonCorp_2F_EventScript_157636
 	bufferitemname 0, ITEM_ROOT_FOSSIL
 	msgbox RustboroCity_DevonCorp_2F_Text_183023, 4
@@ -103,8 +103,8 @@ RustboroCity_DevonCorp_2F_EventScript_1575EE:: @ 81575EE
 	waitmovement 0
 	applymovement 5, RustboroCity_DevonCorp_2F_Movement_1A0835
 	waitmovement 0
-	msgbox RustboroCity_DevonCorp_2F_Text_182F35, 5
-	compare RESULT, 0
+	msgbox RustboroCity_DevonCorp_2F_Text_182F35, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq RustboroCity_DevonCorp_2F_EventScript_157636
 	bufferitemname 0, ITEM_CLAW_FOSSIL
 	msgbox RustboroCity_DevonCorp_2F_Text_183023, 4
@@ -145,8 +145,8 @@ RustboroCity_DevonCorp_2F_EventScript_157661:: @ 8157661
 	waitfanfare
 	waitmessage
 	givemon SPECIES_LILEEP, 20, ITEM_NONE, 0x0, 0x0, 0
-	msgbox RustboroCity_DevonCorp_2F_Text_1A1102, 5
-	compare RESULT, 1
+	msgbox RustboroCity_DevonCorp_2F_Text_1A1102, MSGBOX_YESNO
+	compare RESULT, YES
 	call_if 1, RustboroCity_DevonCorp_2F_EventScript_1A0678
 	release
 	end
@@ -165,8 +165,8 @@ RustboroCity_DevonCorp_2F_EventScript_1576B4:: @ 81576B4
 	waitfanfare
 	waitmessage
 	givemon SPECIES_ANORITH, 20, ITEM_NONE, 0x0, 0x0, 0
-	msgbox RustboroCity_DevonCorp_2F_Text_1A1102, 5
-	compare RESULT, 1
+	msgbox RustboroCity_DevonCorp_2F_Text_1A1102, MSGBOX_YESNO
+	compare RESULT, YES
 	call_if 1, RustboroCity_DevonCorp_2F_EventScript_1A0678
 	release
 	end

--- a/data/scripts/maps/RustboroCity_DevonCorp_3F.inc
+++ b/data/scripts/maps/RustboroCity_DevonCorp_3F.inc
@@ -37,7 +37,7 @@ RustboroCity_DevonCorp_3F_EventScript_157752:: @ 8157752
 	waitmovement 0
 	msgbox RustboroCity_DevonCorp_3F_Text_183903, 4
 	closemessage
-	playbgm 420, 0
+	playbgm BGM_TSURETEK, FALSE
 	applymovement 2, RustboroCity_DevonCorp_3F_Movement_157803
 	applymovement 255, RustboroCity_DevonCorp_3F_Movement_157827
 	waitmovement 0
@@ -50,7 +50,7 @@ RustboroCity_DevonCorp_3F_EventScript_157752:: @ 8157752
 	msgbox RustboroCity_DevonCorp_3F_Text_18320B, 4
 	giveitem_std ITEM_LETTER
 	msgbox RustboroCity_DevonCorp_3F_Text_18337E, 4
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	message RustboroCity_DevonCorp_3F_Text_183422
 	waitfanfare
 	waitmessage

--- a/data/scripts/maps/RustboroCity_House1.inc
+++ b/data/scripts/maps/RustboroCity_House1.inc
@@ -10,8 +10,8 @@ RustboroCity_House1_EventScript_157C7D:: @ 8157C7D
 	copyvar VAR_SPECIAL_4, VAR_SPECIAL_8
 	specialvar RESULT, GetInGameTradeSpeciesInfo
 	copyvar VAR_SPECIAL_9, RESULT
-	msgbox RustboroCity_House1_Text_184EBA, 5
-	compare RESULT, 0
+	msgbox RustboroCity_House1_Text_184EBA, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq RustboroCity_House1_EventScript_157CFB
 	special SelectMonForNPCTrade
 	waitstate

--- a/data/scripts/maps/RusturfTunnel.inc
+++ b/data/scripts/maps/RusturfTunnel.inc
@@ -148,7 +148,7 @@ RusturfTunnel_EventScript_15C91B:: @ 815C91B
 	return
 
 RusturfTunnel_EventScript_15C92D:: @ 815C92D
-	playse 21
+	playse SE_PIN
 	applymovement 1, RusturfTunnel_Movement_1A0833
 	waitmovement 0
 	applymovement 1, RusturfTunnel_Movement_1A0835
@@ -309,7 +309,7 @@ RusturfTunnel_EventScript_15C9D7:: @ 815C9D7
 RusturfTunnel_EventScript_15C9EA:: @ 815C9EA
 	lock
 	faceplayer
-	playbgm BGM_EVIL_TEAM, 0
+	playbgm BGM_EVIL_TEAM, FALSE
 	msgbox RusturfTunnel_Text_19419B, 4
 	trainerbattle 3, OPPONENT_RUSTURF_TUNNEL_GRUNT, 0, RusturfTunnel_Text_194243
 	msgbox RusturfTunnel_Text_194274, 4

--- a/data/scripts/maps/SSTidalCorridor.inc
+++ b/data/scripts/maps/SSTidalCorridor.inc
@@ -13,7 +13,7 @@ SSTidalCorridor_EventScript_15FCBC:: @ 815FCBC
 	special SetSSTidalFlag
 	setvar VAR_PORTHOLE_STATE, 2
 	lockall
-	playse 73
+	playse SE_PINPON
 	msgbox SSTidalCorridor_Text_199007, 4
 	releaseall
 	end
@@ -21,7 +21,7 @@ SSTidalCorridor_EventScript_15FCBC:: @ 815FCBC
 SSTidalCorridor_EventScript_15FCD2:: @ 815FCD2
 	setvar VAR_PORTHOLE_STATE, 6
 	lockall
-	playse 73
+	playse SE_PINPON
 	msgbox SSTidalCorridor_Text_199088, 4
 	releaseall
 	end
@@ -29,14 +29,14 @@ SSTidalCorridor_EventScript_15FCD2:: @ 815FCD2
 SSTidalRooms_EventScript_15FCE5:: @ 815FCE5
 	special SetSSTidalFlag
 	setvar VAR_PORTHOLE_STATE, 7
-	playse 73
+	playse SE_PINPON
 	msgbox SSTidalRooms_Text_199007, 4
 	return
 
 SSTidalRooms_EventScript_15FCF9:: @ 815FCF9
 	special ResetSSTidalFlag
 	setvar VAR_PORTHOLE_STATE, 4
-	playse 73
+	playse SE_PINPON
 	msgbox SSTidalRooms_Text_1990F8, 4
 	return
 
@@ -51,7 +51,7 @@ SSTidalCorridor_EventScript_15FD24:: @ 815FD24
 	special ResetSSTidalFlag
 	setvar VAR_PORTHOLE_STATE, 3
 	lockall
-	playse 73
+	playse SE_PINPON
 	msgbox SSTidalCorridor_Text_199088, 4
 	releaseall
 	end
@@ -60,7 +60,7 @@ SSTidalCorridor_EventScript_15FD3A:: @ 815FD3A
 	special ResetSSTidalFlag
 	setvar VAR_PORTHOLE_STATE, 8
 	lockall
-	playse 73
+	playse SE_PINPON
 	msgbox SSTidalCorridor_Text_1990B4, 4
 	releaseall
 	end
@@ -68,7 +68,7 @@ SSTidalCorridor_EventScript_15FD3A:: @ 815FD3A
 SSTidalRooms_EventScript_15FD50:: @ 815FD50
 	special ResetSSTidalFlag
 	setvar VAR_PORTHOLE_STATE, 8
-	playse 73
+	playse SE_PINPON
 	msgbox SSTidalRooms_Text_1990B4, 4
 	return
 

--- a/data/scripts/maps/SafariZone_Southeast.inc
+++ b/data/scripts/maps/SafariZone_Southeast.inc
@@ -54,8 +54,8 @@ SafariZone_Southeast_EventScript_1600A7:: @ 81600A7
 	faceplayer
 	compare VAR_TEMP_1, 0
 	goto_if_eq SafariZone_Southeast_EventScript_1600D1
-	msgbox SafariZone_Southeast_Text_1C3A56, 5
-	compare RESULT, 1
+	msgbox SafariZone_Southeast_Text_1C3A56, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SafariZone_Southeast_EventScript_1600E0
 	msgbox SafariZone_Southeast_Text_1C3A9C, 4
 	release

--- a/data/scripts/maps/SeafloorCavern_Room9.inc
+++ b/data/scripts/maps/SeafloorCavern_Room9.inc
@@ -78,7 +78,7 @@ SeafloorCavern_Room9_EventScript_15DAFA:: @ 815DAFA
 	.else
 	setvar RESULT, 0
 	.endif
-	playse 209
+	playse SE_W197
 	setfieldeffectargument 0, 16
 	setfieldeffectargument 1, 42
 	setfieldeffectargument 2, 0
@@ -89,8 +89,8 @@ SeafloorCavern_Room9_EventScript_15DAFA:: @ 815DAFA
 	.else
 	setvar RESULT, 1
 	.endif
-	playfanfare 388
-	playse 107
+	playfanfare BGM_ME_TAMA
+	playse SE_TAMA
 	special sub_80818A4
 	applymovement VAR_SPECIAL_4, SeafloorCavern_Room9_Movement_1A0841
 	applymovement 255, SeafloorCavern_Room9_Movement_1A0841
@@ -126,7 +126,7 @@ SeafloorCavern_Room9_EventScript_15DAFA:: @ 815DAFA
 	.else
 	msgbox SeafloorCavern_Room9_Text_1B4A89, 4
 	.endif
-	playse 2
+	playse SE_PC_LOGON
 	applymovement 255, SeafloorCavern_Room9_Movement_1A083F
 	waitmovement 0
 	.ifdef SAPPHIRE
@@ -143,7 +143,7 @@ SeafloorCavern_Room9_EventScript_15DAFA:: @ 815DAFA
 	msgbox SeafloorCavern_Room9_Text_1B4B11, 4
 	.endif
 	closemessage
-	playse 3
+	playse SE_PC_OFF
 	delay 20
 	applymovement VAR_SPECIAL_4, SeafloorCavern_Room9_Movement_1A0845
 	waitmovement 0
@@ -167,7 +167,7 @@ SeafloorCavern_Room9_EventScript_15DAFA:: @ 815DAFA
 	.else
 	msgbox SeafloorCavern_Room9_Text_1B4D02, 4
 	.endif
-	playse 21
+	playse SE_PIN
 	applymovement VAR_SPECIAL_4, SeafloorCavern_Room9_Movement_1A0833
 	waitmovement 0
 	applymovement VAR_SPECIAL_4, SeafloorCavern_Room9_Movement_1A0835

--- a/data/scripts/maps/SeafloorCavern_Room9.inc
+++ b/data/scripts/maps/SeafloorCavern_Room9.inc
@@ -62,7 +62,7 @@ SeafloorCavern_Room9_EventScript_15DAFA:: @ 815DAFA
 	.else
 	msgbox SeafloorCavern_Room9_Text_1B49C1, 4
 	.endif
-	setweather 0
+	setweather WEATHER_NONE
 	doweather
 	special sub_8081924
 	waitstate

--- a/data/scripts/maps/SealedChamber_InnerRoom.inc
+++ b/data/scripts/maps/SealedChamber_InnerRoom.inc
@@ -12,21 +12,21 @@ SealedChamber_InnerRoom_EventScript_15F1E8:: @ 815F1E8
 	compare RESULT, 0
 	goto_if_eq SealedChamber_InnerRoom_EventScript_15F247
 	fadeoutbgm 0
-	playse 49
+	playse SE_TRACK_MOVE
 	special DoSealedChamberShakingEffect1
 	waitstate
 	delay 40
 	special DoSealedChamberShakingEffect2
 	waitstate
-	playse 8
+	playse SE_DOOR
 	delay 40
 	special DoSealedChamberShakingEffect2
 	waitstate
-	playse 8
+	playse SE_DOOR
 	delay 40
 	special DoSealedChamberShakingEffect2
 	waitstate
-	playse 8
+	playse SE_DOOR
 	delay 40
 	msgbox SealedChamber_InnerRoom_Text_1A138B, 4
 	closemessage

--- a/data/scripts/maps/ShoalCave_LowTideEntranceRoom.inc
+++ b/data/scripts/maps/ShoalCave_LowTideEntranceRoom.inc
@@ -28,8 +28,8 @@ ShoalCave_LowTideEntranceRoom_EventScript_15E076:: @ 815E076
 	checkitem ITEM_SHOAL_SHELL, 4
 	compare RESULT, 0
 	goto_if_eq ShoalCave_LowTideEntranceRoom_EventScript_15E138
-	msgbox ShoalCave_LowTideEntranceRoom_Text_1C6793, 5
-	compare RESULT, 0
+	msgbox ShoalCave_LowTideEntranceRoom_Text_1C6793, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq ShoalCave_LowTideEntranceRoom_EventScript_15E16C
 	checkitemspace ITEM_SHELL_BELL, 1
 	compare RESULT, 0

--- a/data/scripts/maps/SlateportCity.inc
+++ b/data/scripts/maps/SlateportCity.inc
@@ -287,10 +287,10 @@ SlateportCity_EventScript_14BCFD:: @ 814BCFD
 SlateportCity_EventScript_14BD06:: @ 814BD06
 	lock
 	faceplayer
-	msgbox SlateportCity_Text_1650F1, 5
-	compare RESULT, 1
+	msgbox SlateportCity_Text_1650F1, MSGBOX_YESNO
+	compare RESULT, YES
 	call_if 1, SlateportCity_EventScript_14BD28
-	compare RESULT, 0
+	compare RESULT, NO
 	call_if 1, SlateportCity_EventScript_14BD31
 	release
 	end

--- a/data/scripts/maps/SlateportCity.inc
+++ b/data/scripts/maps/SlateportCity.inc
@@ -73,7 +73,7 @@ SlateportCity_EventScript_14BAE0:: @ 814BAE0
 	compare RESULT, 0
 	call_if 1, SlateportCity_EventScript_14BB2B
 	msgbox SlateportCity_Text_164691, 4
-	playfanfare 370
+	playfanfare BGM_FANFA4
 	message SlateportCity_Text_1646DD
 	waitfanfare
 	waitmessage
@@ -508,7 +508,7 @@ SlateportCity_EventScript_14BEBC:: @ 814BEBC
 	applymovement 11, SlateportCity_Movement_1A0841
 	waitmovement 0
 	msgbox SlateportCity_Text_1655E7, 4
-	playbgm BGM_EVIL_TEAM, 0
+	playbgm BGM_EVIL_TEAM, FALSE
 	msgbox SlateportCity_Text_1656BC, 4
 	applymovement 6, SlateportCity_Movement_1A083F
 	applymovement 1, SlateportCity_Movement_1A083F
@@ -519,7 +519,7 @@ SlateportCity_EventScript_14BEBC:: @ 814BEBC
 	applymovement 11, SlateportCity_Movement_1A0845
 	waitmovement 0
 	msgbox SlateportCity_Text_16578F, 4
-	playse 21
+	playse SE_PIN
 	applymovement 11, SlateportCity_Movement_1A0833
 	waitmovement 0
 	applymovement 11, SlateportCity_Movement_1A0835

--- a/data/scripts/maps/SlateportCity_ContestLobby.inc
+++ b/data/scripts/maps/SlateportCity_ContestLobby.inc
@@ -22,13 +22,13 @@ SlateportCity_ContestLobby_EventScript_155448:: @ 8155448
 	lockall
 	applymovement 1, SlateportCity_ContestLobby_Movement_1554CC
 	waitmovement 0
-	playse 71
+	playse SE_HASHI
 	setmetatile 4, 2, 545, 1
 	setmetatile 4, 3, 609, 1
 	special DrawWholeMapView
 	applymovement 1, SlateportCity_ContestLobby_Movement_1554CF
 	waitmovement 0
-	playse 71
+	playse SE_HASHI
 	setmetatile 4, 2, 721, 1
 	setmetatile 4, 3, 729, 1
 	special DrawWholeMapView

--- a/data/scripts/maps/SlateportCity_Harbor.inc
+++ b/data/scripts/maps/SlateportCity_Harbor.inc
@@ -190,8 +190,8 @@ SlateportCity_Harbor_EventScript_156135:: @ 8156135
 	end
 
 SlateportCity_Harbor_EventScript_15613F:: @ 815613F
-	msgbox SlateportCity_Harbor_Text_17FB81, 5
-	compare RESULT, 0
+	msgbox SlateportCity_Harbor_Text_17FB81, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SlateportCity_Harbor_EventScript_15618A
 	setvar VAR_PORTHOLE_STATE, 1
 	call SlateportCity_Harbor_EventScript_156196
@@ -201,8 +201,8 @@ SlateportCity_Harbor_EventScript_15613F:: @ 815613F
 	end
 
 SlateportCity_Harbor_EventScript_156167:: @ 8156167
-	msgbox SlateportCity_Harbor_Text_17FB9C, 5
-	compare RESULT, 0
+	msgbox SlateportCity_Harbor_Text_17FB9C, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SlateportCity_Harbor_EventScript_15618A
 	call SlateportCity_Harbor_EventScript_156196
 	warp MAP_BATTLE_TOWER_OUTSIDE, 255, 19, 23
@@ -332,8 +332,8 @@ SlateportCity_Harbor_EventScript_1562B3:: @ 81562B3
 	end
 
 SlateportCity_Harbor_EventScript_1562EA:: @ 81562EA
-	msgbox SlateportCity_Harbor_Text_1803DD, 5
-	compare RESULT, 0
+	msgbox SlateportCity_Harbor_Text_1803DD, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SlateportCity_Harbor_EventScript_156374
 	giveitem_std ITEM_DEEP_SEA_TOOTH
 	compare RESULT, 0
@@ -345,8 +345,8 @@ SlateportCity_Harbor_EventScript_1562EA:: @ 81562EA
 	end
 
 SlateportCity_Harbor_EventScript_15632A:: @ 815632A
-	msgbox SlateportCity_Harbor_Text_180412, 5
-	compare RESULT, 0
+	msgbox SlateportCity_Harbor_Text_180412, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SlateportCity_Harbor_EventScript_156374
 	giveitem_std ITEM_DEEP_SEA_SCALE
 	compare RESULT, 0

--- a/data/scripts/maps/SlateportCity_House1.inc
+++ b/data/scripts/maps/SlateportCity_House1.inc
@@ -4,10 +4,10 @@ SlateportCity_House1_MapScripts:: @ 815567A
 SlateportCity_House1_EventScript_15567B:: @ 815567B
 	lock
 	faceplayer
-	msgbox SlateportCity_House1_Text_17D46A, 5
-	compare RESULT, 1
+	msgbox SlateportCity_House1_Text_17D46A, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SlateportCity_House1_EventScript_15569C
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq SlateportCity_House1_EventScript_1556BF
 	end
 
@@ -38,10 +38,10 @@ SlateportCity_House1_EventScript_1556C9:: @ 81556C9
 	special TV_CopyNicknameToStringVar1AndEnsureTerminated
 	compare RESULT, 1
 	goto_if_eq SlateportCity_House1_EventScript_155726
-	msgbox SlateportCity_House1_Text_17D505, 5
-	compare RESULT, 1
+	msgbox SlateportCity_House1_Text_17D505, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SlateportCity_House1_EventScript_155730
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq SlateportCity_House1_EventScript_1556BF
 	end
 

--- a/data/scripts/maps/SlateportCity_OceanicMuseum_1F.inc
+++ b/data/scripts/maps/SlateportCity_OceanicMuseum_1F.inc
@@ -158,7 +158,7 @@ SlateportCity_OceanicMuseum_1F_EventScript_155C3A:: @ 8155C3A
 	lock
 	faceplayer
 	delay 8
-	playse 21
+	playse SE_PIN
 	applymovement 13, SlateportCity_OceanicMuseum_1F_Movement_1A0833
 	waitmovement 0
 	applymovement 13, SlateportCity_OceanicMuseum_1F_Movement_1A0835
@@ -180,7 +180,7 @@ SlateportCity_OceanicMuseum_1F_EventScript_155C98:: @ 8155C98
 	applymovement 13, SlateportCity_OceanicMuseum_1F_Movement_155CD3
 	waitmovement 0
 	setflag FLAG_HIDE_SCARED_GRUNT_OCEANIC_MUSEUM
-	playse 9
+	playse SE_KAIDAN
 	removeobject 13
 	release
 	end
@@ -189,7 +189,7 @@ SlateportCity_OceanicMuseum_1F_EventScript_155CAD:: @ 8155CAD
 	applymovement 13, SlateportCity_OceanicMuseum_1F_Movement_155CCC
 	waitmovement 0
 	setflag FLAG_HIDE_SCARED_GRUNT_OCEANIC_MUSEUM
-	playse 9
+	playse SE_KAIDAN
 	removeobject 13
 	release
 	end

--- a/data/scripts/maps/SlateportCity_OceanicMuseum_1F.inc
+++ b/data/scripts/maps/SlateportCity_OceanicMuseum_1F.inc
@@ -33,8 +33,8 @@ SlateportCity_OceanicMuseum_1F_EventScript_155AF5:: @ 8155AF5
 SlateportCity_OceanicMuseum_1F_EventScript_155B06:: @ 8155B06
 	showmoneybox 0, 0
 	nop
-	msgbox SlateportCity_OceanicMuseum_1F_Text_17E18D, 5
-	compare RESULT, 1
+	msgbox SlateportCity_OceanicMuseum_1F_Text_17E18D, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SlateportCity_OceanicMuseum_1F_EventScript_155B2D
 	closemessage
 	hidemoneybox 0, 0

--- a/data/scripts/maps/SlateportCity_OceanicMuseum_2F.inc
+++ b/data/scripts/maps/SlateportCity_OceanicMuseum_2F.inc
@@ -11,7 +11,7 @@ SlateportCity_OceanicMuseum_2F_EventScript_155CE6:: @ 8155CE6
 	faceplayer
 	msgbox SlateportCity_OceanicMuseum_2F_Text_17ECFD, 4
 	closemessage
-	playbgm BGM_EVIL_TEAM, 1
+	playbgm BGM_EVIL_TEAM, TRUE
 	addobject 3
 	applymovement 3, SlateportCity_OceanicMuseum_2F_Movement_155EB4
 	waitmovement 0
@@ -84,7 +84,7 @@ SlateportCity_OceanicMuseum_2F_EventScript_155CE6:: @ 8155CE6
 	closemessage
 	applymovement 1, SlateportCity_OceanicMuseum_2F_Movement_155E98
 	waitmovement 0
-	playse 9
+	playse SE_KAIDAN
 	removeobject 1
 	setflag FLAG_HIDE_EVIL_TEAM_ROUTE110
 	setflag FLAG_DELIVERED_DEVON_GOODS

--- a/data/scripts/maps/SlateportCity_PokemonFanClub.inc
+++ b/data/scripts/maps/SlateportCity_PokemonFanClub.inc
@@ -206,7 +206,7 @@ SlateportCity_PokemonFanClub_EventScript_155A15:: @ 8155A15
 	end
 
 SlateportCity_PokemonFanClub_EventScript_155A3A:: @ 8155A3A
-	playse 21
+	playse SE_PIN
 	applymovement LAST_TALKED, SlateportCity_PokemonFanClub_Movement_1A0833
 	waitmovement 0
 	applymovement LAST_TALKED, SlateportCity_PokemonFanClub_Movement_1A0835

--- a/data/scripts/maps/SootopolisCity.inc
+++ b/data/scripts/maps/SootopolisCity.inc
@@ -127,8 +127,8 @@ SootopolisCity_EventScript_14D220:: @ 814D220
 	end
 
 SootopolisCity_EventScript_14D241:: @ 814D241
-	msgbox SootopolisCity_Text_1C6540, 5
-	compare RESULT, 1
+	msgbox SootopolisCity_Text_1C6540, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SootopolisCity_EventScript_14D25E
 	msgbox SootopolisCity_Text_1C6626, 4
 	release

--- a/data/scripts/maps/SootopolisCity.inc
+++ b/data/scripts/maps/SootopolisCity.inc
@@ -216,7 +216,7 @@ SootopolisCity_EventScript_14D308:: @ 814D308
 	applymovement 10, SootopolisCity_Movement_1A083F
 	applymovement 255, SootopolisCity_Movement_1A0843
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement 10, SootopolisCity_Movement_1A0833
 	waitmovement 0
 	applymovement 10, SootopolisCity_Movement_1A0835
@@ -237,7 +237,7 @@ SootopolisCity_EventScript_14D308:: @ 814D308
 	.else
 	msgbox SootopolisCity_Text_169E82, 4
 	.endif
-	playse 21
+	playse SE_PIN
 	applymovement 5, SootopolisCity_Movement_1A0833
 	waitmovement 0
 	applymovement 5, SootopolisCity_Movement_1A0835

--- a/data/scripts/maps/SootopolisCity_Gym_1F.inc
+++ b/data/scripts/maps/SootopolisCity_Gym_1F.inc
@@ -49,7 +49,7 @@ SootopolisCity_Gym_1F_MapScript2_15AF86:: @ 815AF86
 SootopolisCity_Gym_1F_EventScript_15AFA8:: @ 815AFA8
 	addvar VAR_ICE_STEP_COUNT, 1
 	delay 40
-	playse 40
+	playse SE_RU_GASHIN
 	call SootopolisCity_Gym_1F_EventScript_15AF2E
 	special DrawWholeMapView
 	end
@@ -57,7 +57,7 @@ SootopolisCity_Gym_1F_EventScript_15AFA8:: @ 815AFA8
 SootopolisCity_Gym_1F_EventScript_15AFBC:: @ 815AFBC
 	addvar VAR_ICE_STEP_COUNT, 1
 	delay 40
-	playse 40
+	playse SE_RU_GASHIN
 	call SootopolisCity_Gym_1F_EventScript_15AF2E
 	special DrawWholeMapView
 	end
@@ -65,7 +65,7 @@ SootopolisCity_Gym_1F_EventScript_15AFBC:: @ 815AFBC
 SootopolisCity_Gym_1F_EventScript_15AFD0:: @ 815AFD0
 	addvar VAR_ICE_STEP_COUNT, 1
 	delay 40
-	playse 40
+	playse SE_RU_GASHIN
 	call SootopolisCity_Gym_1F_EventScript_15AF2E
 	special DrawWholeMapView
 	end
@@ -75,7 +75,7 @@ SootopolisCity_Gym_1F_EventScript_15AFE4:: @ 815AFE4
 	delay 20
 	applymovement 255, SootopolisCity_Gym_1F_Movement_15AFFD
 	waitmovement 0
-	playse 43
+	playse SE_RU_HYUU
 	delay 60
 	warphole MAP_SOOTOPOLIS_CITY_GYM_B1F
 	waitstate

--- a/data/scripts/maps/SootopolisCity_House2.inc
+++ b/data/scripts/maps/SootopolisCity_House2.inc
@@ -4,10 +4,10 @@ SootopolisCity_House2_MapScripts:: @ 815B2E4
 SootopolisCity_House2_EventScript_15B2E5:: @ 815B2E5
 	lock
 	faceplayer
-	msgbox SootopolisCity_House2_Text_18FA66, 5
-	compare RESULT, 1
+	msgbox SootopolisCity_House2_Text_18FA66, MSGBOX_YESNO
+	compare RESULT, YES
 	call_if 1, SootopolisCity_House2_EventScript_15B307
-	compare RESULT, 0
+	compare RESULT, NO
 	call_if 1, SootopolisCity_House2_EventScript_15B310
 	release
 	end

--- a/data/scripts/maps/SootopolisCity_House3.inc
+++ b/data/scripts/maps/SootopolisCity_House3.inc
@@ -4,8 +4,8 @@ SootopolisCity_House3_MapScripts:: @ 815B319
 SootopolisCity_House3_EventScript_15B31A:: @ 815B31A
 	lock
 	faceplayer
-	msgbox SootopolisCity_House3_Text_18FB36, 5
-	compare RESULT, 1
+	msgbox SootopolisCity_House3_Text_18FB36, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq SootopolisCity_House3_EventScript_15B339
 	msgbox SootopolisCity_House3_Text_18FBC0, 4
 	release

--- a/data/scripts/maps/SootopolisCity_House6.inc
+++ b/data/scripts/maps/SootopolisCity_House6.inc
@@ -6,8 +6,8 @@ SootopolisCity_House6_EventScript_15B386:: @ 815B386
 	faceplayer
 	checkflag FLAG_RECEIVED_WAILMER_DOLL
 	goto_if_eq SootopolisCity_House6_EventScript_15B3CD
-	msgbox SootopolisCity_House6_Text_18FEA1, 5
-	compare RESULT, 0
+	msgbox SootopolisCity_House6_Text_18FEA1, MSGBOX_YESNO
+	compare RESULT, NO
 	call_if 1, SootopolisCity_House6_EventScript_15B3C3
 	msgbox SootopolisCity_House6_Text_18FF12, 4
 	givedecoration_std DECOR_WAILMER_DOLL

--- a/data/scripts/maps/SouthernIsland_Exterior.inc
+++ b/data/scripts/maps/SouthernIsland_Exterior.inc
@@ -9,8 +9,8 @@ SouthernIsland_Exterior_MapScript1_160ADC:: @ 8160ADC
 SouthernIsland_Exterior_EventScript_160AE0:: @ 8160AE0
 	lock
 	faceplayer
-	msgbox SouthernIsland_Exterior_Text_1C5215, 5
-	compare RESULT, 0
+	msgbox SouthernIsland_Exterior_Text_1C5215, MSGBOX_YESNO
+	compare RESULT, NO
 	goto_if_eq SouthernIsland_Exterior_EventScript_160B25
 	msgbox SouthernIsland_Exterior_Text_1C5281, 4
 	closemessage

--- a/data/scripts/maps/UnknownMap_25_34.inc
+++ b/data/scripts/maps/UnknownMap_25_34.inc
@@ -26,23 +26,23 @@ LinkContestRoom1_EventScript_15F5A5:: @ 815F5A5
 	return
 
 LinkContestRoom1_EventScript_15F5E0:: @ 815F5E0
-	savebgm 393
+	savebgm BGM_TEST1
 	return
 
 LinkContestRoom1_EventScript_15F5E4:: @ 815F5E4
-	savebgm 394
+	savebgm BGM_TEST2
 	return
 
 LinkContestRoom1_EventScript_15F5E8:: @ 815F5E8
-	savebgm 395
+	savebgm BGM_TEST3
 	return
 
 LinkContestRoom1_EventScript_15F5EC:: @ 815F5EC
-	savebgm 396
+	savebgm BGM_TEST4
 	return
 
 LinkContestRoom1_EventScript_15F5F0:: @ 815F5F0
-	savebgm 440
+	savebgm BGM_CONTEST0
 	return
 
 LinkContestRoom1_MapScript1_15F5F4:: @ 815F5F4

--- a/data/scripts/maps/VerdanturfTown_ContestLobby.inc
+++ b/data/scripts/maps/VerdanturfTown_ContestLobby.inc
@@ -22,13 +22,13 @@ VerdanturfTown_ContestLobby_EventScript_153DA1:: @ 8153DA1
 	lockall
 	applymovement 1, VerdanturfTown_ContestLobby_Movement_153E25
 	waitmovement 0
-	playse 71
+	playse SE_HASHI
 	setmetatile 4, 2, 545, 1
 	setmetatile 4, 3, 609, 1
 	special DrawWholeMapView
 	applymovement 1, VerdanturfTown_ContestLobby_Movement_153E28
 	waitmovement 0
-	playse 71
+	playse SE_HASHI
 	setmetatile 4, 2, 721, 1
 	setmetatile 4, 3, 729, 1
 	special DrawWholeMapView

--- a/data/scripts/mauville_man.inc
+++ b/data/scripts/mauville_man.inc
@@ -141,7 +141,7 @@ do_trader_menu_get:
 	waitstate
 	compare VAR_SPECIAL_4, 0
 	goto_if_eq cancelled_get_menu
-	compare VAR_SPECIAL_4, 65535
+	compare VAR_SPECIAL_4, -1
 	goto_if_eq rare_item_cant_trade_away
 	msgbox gTextTrader_ItemOnceBelongedTo, MSGBOX_YESNO
 	compare RESULT, NO
@@ -178,7 +178,7 @@ do_trader_menu_give:
 	waitstate
 	compare VAR_SPECIAL_6, 0
 	goto_if_eq cancelled_give_menu
-	compare VAR_SPECIAL_6, 65535
+	compare VAR_SPECIAL_6, -1
 	goto_if_eq decoration_is_in_use
 	special ScrSpecial_IsDecorationFull
 	compare RESULT, 1

--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -73,7 +73,7 @@ LittlerootTown_MaysHouse_2F_EventScript_1B69EB:: @ 81B69EB
 	call_if 1, LittlerootTown_BrendansHouse_2F_EventScript_1B6A31
 	compare RESULT, 1
 	call_if 1, LittlerootTown_BrendansHouse_2F_EventScript_1B6A61
-	playse 9
+	playse SE_KAIDAN
 	removeobject VAR_SPECIAL_8
 	releaseall
 	end
@@ -160,7 +160,7 @@ LittlerootTown_BrendansHouse_1F_EventScript_1B6ABF:: @ 81B6ABF
 	call LittlerootTown_BrendansHouse_1F_EventScript_1B6B9D
 	applymovement 255, LittlerootTown_BrendansHouse_1F_Movement_1B6CCC
 	waitmovement 0
-	playbgm 453, 0
+	playbgm BGM_INTER_V, FALSE
 	msgbox LittlerootTown_BrendansHouse_1F_Text_1725C9, 4
 	closemessage
 	applymovement VAR_SPECIAL_5, LittlerootTown_BrendansHouse_1F_Movement_1B6BDB
@@ -185,7 +185,7 @@ LittlerootTown_MaysHouse_1F_EventScript_1B6B2E:: @ 81B6B2E
 	call LittlerootTown_MaysHouse_1F_EventScript_1B6B9D
 	applymovement 255, LittlerootTown_MaysHouse_1F_Movement_1B6CD4
 	waitmovement 0
-	playbgm 453, 0
+	playbgm BGM_INTER_V, FALSE
 	msgbox LittlerootTown_MaysHouse_1F_Text_1725C9, 4
 	closemessage
 	applymovement VAR_SPECIAL_5, LittlerootTown_MaysHouse_1F_Movement_1B6BDE
@@ -206,7 +206,7 @@ LittlerootTown_MaysHouse_1F_EventScript_1B6B2E:: @ 81B6B2E
 
 LittlerootTown_BrendansHouse_1F_EventScript_1B6B9D:: @ 81B6B9D
 LittlerootTown_MaysHouse_1F_EventScript_1B6B9D:: @ 81B6B9D
-	playse 21
+	playse SE_PIN
 	applymovement VAR_SPECIAL_5, LittlerootTown_BrendansHouse_1F_Movement_1A0833
 	waitmovement 0
 	applymovement VAR_SPECIAL_5, LittlerootTown_BrendansHouse_1F_Movement_1A0835
@@ -372,7 +372,7 @@ LittlerootTown_MaysHouse_1F_EventScript_1B6CDE:: @ 81B6CDE
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_1B6E28
 	applymovement VAR_SPECIAL_9, LittlerootTown_BrendansHouse_1F_Movement_1A0839
 	waitmovement 0
-	playse 21
+	playse SE_PIN
 	applymovement VAR_SPECIAL_9, LittlerootTown_BrendansHouse_1F_Movement_1A0833
 	waitmovement 0
 	applymovement VAR_SPECIAL_9, LittlerootTown_BrendansHouse_1F_Movement_1A0835
@@ -396,7 +396,7 @@ LittlerootTown_MaysHouse_1F_EventScript_1B6CDE:: @ 81B6CDE
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_1B6DF9
 	compare VAR_SPECIAL_8, 1
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_1B6E0B
-	playse 8
+	playse SE_DOOR
 	removeobject VAR_SPECIAL_9
 	setflag FLAG_RECEIVED_SS_TICKET
 	setvar VAR_LITTLEROOT_HOUSES_STATE, 4

--- a/data/scripts/pokeblocks.inc
+++ b/data/scripts/pokeblocks.inc
@@ -54,9 +54,9 @@ FallarborTown_ContestLobby_EventScript_1B76A1:: @ 81B76A1
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1B770E
 	msgbox FallarborTown_ContestLobby_Text_1B6E9D, 4
 	specialvar RESULT, GetFirstFreePokeblockSlot
-	compare RESULT, 65535
+	compare RESULT, -1
 	goto_if 5, FallarborTown_ContestLobby_EventScript_1B76EF
-	compare RESULT, 65535
+	compare RESULT, -1
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1B7776
 	end
 
@@ -215,9 +215,9 @@ VerdanturfTown_ContestLobby_EventScript_1B783B:: @ 81B783B
 	compare RESULT, 0
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1B7942
 	specialvar RESULT, GetFirstFreePokeblockSlot
-	compare RESULT, 65535
+	compare RESULT, -1
 	goto_if 5, FallarborTown_ContestLobby_EventScript_1B7878
-	compare RESULT, 65535
+	compare RESULT, -1
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1B7938
 	end
 

--- a/data/scripts/pokeblocks.inc
+++ b/data/scripts/pokeblocks.inc
@@ -38,10 +38,10 @@ LilycoveCity_ContestLobby_EventScript_1B7681:: @ 81B7681
 SlateportCity_ContestLobby_EventScript_1B7681:: @ 81B7681
 VerdanturfTown_ContestLobby_EventScript_1B7681:: @ 81B7681
 	lockall
-	msgbox FallarborTown_ContestLobby_Text_1B6E63, 5
-	compare RESULT, 1
+	msgbox FallarborTown_ContestLobby_Text_1B6E63, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1B76A1
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1B76E5
 	end
 
@@ -66,10 +66,10 @@ FallarborTown_ContestLobby_EventScript_1B76E5:: @ 81B76E5
 	end
 
 FallarborTown_ContestLobby_EventScript_1B76EF:: @ 81B76EF
-	msgbox FallarborTown_ContestLobby_Text_1B6ED0, 5
-	compare RESULT, 1
+	msgbox FallarborTown_ContestLobby_Text_1B6ED0, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1B7734
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1B7726
 	end
 
@@ -222,10 +222,10 @@ VerdanturfTown_ContestLobby_EventScript_1B783B:: @ 81B783B
 	end
 
 FallarborTown_ContestLobby_EventScript_1B7878:: @ 81B7878
-	msgbox FallarborTown_ContestLobby_Text_1B727C, 5
-	compare RESULT, 1
+	msgbox FallarborTown_ContestLobby_Text_1B727C, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1B78A1
-	compare RESULT, 0
+	compare RESULT, NO
 	goto_if_eq FallarborTown_ContestLobby_EventScript_1B7936
 	end
 

--- a/data/scripts/safari_zone.inc
+++ b/data/scripts/safari_zone.inc
@@ -13,8 +13,8 @@ EventScript_1C341B: @ 81C341B
 
 gUnknown_081C342D:: @ 81C342D
 	lockall
-	msgbox UnknownString_81C34B2, 5
-	compare RESULT, 1
+	msgbox UnknownString_81C34B2, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq EventScript_1C3443
 	releaseall
 	end
@@ -45,8 +45,8 @@ gUnknown_081C346A:: @ 81C346A
 	special SafariZoneGetPokeblockNameInFeeder
 	compare RESULT, 0xFFFF
 	goto_if 5, EventScript_1C34A9
-	msgbox UnknownString_81C354E, 5
-	compare RESULT, 1
+	msgbox UnknownString_81C354E, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq EventScript_1C348E
 	releaseall
 	end

--- a/data/scripts/safari_zone.inc
+++ b/data/scripts/safari_zone.inc
@@ -24,7 +24,7 @@ EventScript_1C3443:
 
 gUnknown_081C3448:: @ 81C3448
 	lockall
-	playse 73
+	playse SE_PINPON
 	message UnknownString_81C34E4
 	waitmessage
 	waitbuttonpress
@@ -33,7 +33,7 @@ gUnknown_081C3448:: @ 81C3448
 
 gUnknown_081C3459:: @ 81C3459
 	lockall
-	playse 73
+	playse SE_PINPON
 	message UnknownString_81C3514
 	waitmessage
 	waitbuttonpress

--- a/data/scripts/secret_power_tm.inc
+++ b/data/scripts/secret_power_tm.inc
@@ -1,8 +1,8 @@
 Route111_EventScript_1A3858:: @ 81A3858
 	lock
 	faceplayer
-	msgbox Route111_Text_1A3520, 5
-	compare RESULT, 1
+	msgbox Route111_Text_1A3520, MSGBOX_YESNO
+	compare RESULT, YES
 	goto_if_eq Route111_EventScript_1A3877
 	msgbox Route111_Text_1A37B5, 4
 	release


### PR DESCRIPTION
-Use constants in scripts for items, songs, weather, and yes/no choices.
-Support `-1` as an immediate value when using the `compare` script command.