### PR TITLE
Fix broken builds after running make without tools installed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,8 @@ endif
 .SUFFIXES:
 # Don't delete intermediate files
 .SECONDARY:
+# Delete files that weren't built properly
+.DELETE_ON_ERROR:
 
 # Create build subdirectories
 $(shell mkdir -p $(addprefix $(BUILD_DIR)/, $(SUBDIRS)))


### PR DESCRIPTION
The culprit is the .ld file recipes, which create the file even if the command failed.
These could be fixed on their own, but this way prevents it from happening again later.