### PR TITLE
make special ids global

### DIFF
--- a/data/specials.inc
+++ b/data/specials.inc
@@ -1,4 +1,5 @@
 .macro def_special ptr
+.global SPECIAL_\ptr
 .set SPECIAL_\ptr, __special__
 .set __special__, __special__ + 1
     .4byte \ptr


### PR DESCRIPTION
this isn't required, but if specials are used in more than one object later this will avoid some head scratching