### PR TITLE
Remove superfluous compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ RAMSCRGEN := tools/ramscrgen/ramscrgen
 
 ASFLAGS  := -mcpu=arm7tdmi -I include --defsym $(GAME_VERSION)=1 --defsym REVISION=$(GAME_REVISION) --defsym $(GAME_LANGUAGE)=1
 CC1FLAGS := -mthumb-interwork -Wimplicit -Wparentheses -Wunused -Werror -O2 -fhex-asm
-CPPFLAGS := -I tools/agbcc/include -iquote include -nostdinc -undef -Werror -Wno-trigraphs -D $(GAME_VERSION) -D REVISION=$(GAME_REVISION) -D $(GAME_LANGUAGE)
+CPPFLAGS := -I tools/agbcc/include -iquote include -Werror -Wno-trigraphs -D $(GAME_VERSION) -D REVISION=$(GAME_REVISION) -D $(GAME_LANGUAGE)
 
 
 #### Files ####


### PR DESCRIPTION
The `-undef` and `-nostdinc` flags are not needed to match, and `-undef` in particular causes the compiler to error when seeing `#include <math.h>` (which some may want to do later on e.g.. to call standard floating point functions such as `sinf`, `logf`, `fmaxf`, etc.)