### PR TITLE
Add EGG_HATCH_LEVEL define and use when appropriate

### DIFF
--- a/include/daycare.h
+++ b/include/daycare.h
@@ -1,6 +1,8 @@
 #ifndef GUARD_DAYCARE_H
 #define GUARD_DAYCARE_H
 
+#define EGG_HATCH_LEVEL 5
+
 u8 *GetMonNick(struct Pokemon *, u8 *);
 u8 *GetBoxMonNick(struct BoxPokemon *, u8 *);
 u8 CountPokemonInDaycare(struct DayCare *);

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -1036,7 +1036,7 @@ void CreateEgg(struct Pokemon *mon, u16 species, bool8 setMetLocation)
     u8 metLocation;
     u8 isEgg;
 
-    CreateMon(mon, species, 5, 0x20, FALSE, 0, FALSE, 0);
+    CreateMon(mon, species, EGG_HATCH_LEVEL, 0x20, FALSE, 0, FALSE, 0);
     metLevel = 0;
     ball = ITEM_POKE_BALL;
     language = LANGUAGE_JAPANESE;
@@ -1063,7 +1063,7 @@ static void SetInitialEggData(struct Pokemon *mon, u16 species, struct DayCare *
     u8 language;
 
     personality = daycare->misc.countersEtc.pendingEggPersonality | (Random() << 16);
-    CreateMon(mon, species, 5, 0x20, TRUE, personality, FALSE, 0);
+    CreateMon(mon, species, EGG_HATCH_LEVEL, 0x20, TRUE, personality, FALSE, 0);
     metLevel = 0;
     ball = ITEM_POKE_BALL;
     language = LANGUAGE_JAPANESE;

--- a/src/egg_hatch.c
+++ b/src/egg_hatch.c
@@ -244,7 +244,7 @@ static void CreatedHatchedMon(struct Pokemon *egg, struct Pokemon *temp)
     markings = GetMonData(egg, MON_DATA_MARKINGS);
     pokerus = GetMonData(egg, MON_DATA_POKERUS);
 
-    CreateMon(temp, species, 5, 32, TRUE, personality, 0, 0);
+    CreateMon(temp, species, EGG_HATCH_LEVEL, 32, TRUE, personality, 0, 0);
 
     for (i = 0; i < 4; i++)
     {

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -30,6 +30,7 @@
 #include "task.h"
 #include "tv.h"
 #include "scanline_effect.h"
+#include "daycare.h"
 
 static void sub_809FC0C(void);
 static void sub_809FEB8(void);
@@ -3052,7 +3053,7 @@ static void PokemonSummaryScreen_PrintTrainerMemo(struct Pokemon *mon, u8 left, 
 
         if (GetMonData(mon, MON_DATA_MET_LEVEL) == 0)
         {
-            ptr = PokemonSummaryScreen_CopyPokemonLevel(ptr, 5);
+            ptr = PokemonSummaryScreen_CopyPokemonLevel(ptr, EGG_HATCH_LEVEL);
             *ptr = CHAR_NEWLINE;
             ptr++;
 


### PR DESCRIPTION
To make pokeruby more consistent with pokeemerald, this PR adds the EGG_HATCH_LEVEL define to daycare.h and updates pokemon_summary_screen.c, egg_hatch.c, and daycare.c to use it.

Trying this again...