### PR TITLE
Rename sub_804C1A8() in trade.c to SetTradeSceneStrings()

### DIFF
--- a/src/trade.c
+++ b/src/trade.c
@@ -207,7 +207,7 @@ static void sub_804E1DC(void);
 static void sub_804BBCC(void);
 static void sub_804D8E4(void);
 static void sub_804C164(void);
-static void GetTradeSceneStrings(void);
+static void SetTradeSceneStrings(void);
 #ifdef NONMATCHING
 static
 #endif
@@ -4096,7 +4096,7 @@ static void sub_804B41C(void)
         case 11:
             sub_804BBE8(5);
             sub_804BBE8(0);
-            GetTradeSceneStrings();
+            SetTradeSceneStrings();
             BeginNormalPaletteFade(-1, 0, 16, 0, 0);
             gMain.state ++;
             break;
@@ -4451,7 +4451,7 @@ static NAKED void sub_804B41C(void)
                     "\tbl sub_804BBE8\n"
                     "\tmovs r0, 0\n"
                     "\tbl sub_804BBE8\n"
-                    "\tbl GetTradeSceneStrings\n"
+                    "\tbl SetTradeSceneStrings\n"
                     "\tmovs r0, 0x1\n"
                     "\tnegs r0, r0\n"
                     "\tmovs r1, 0\n"
@@ -4563,7 +4563,7 @@ void sub_804B790(void)
         case 11:
             sub_804BBE8(5);
             sub_804BBE8(0);
-            GetTradeSceneStrings();
+            SetTradeSceneStrings();
             BeginNormalPaletteFade(-1, 0, 16, 0, 0);
             gMain.state ++;
             break;
@@ -4772,9 +4772,9 @@ static void sub_804C164(void)
     LoadSpritePalette(&gUnknown_082159B4);
 }
 
-static void GetTradeSceneStrings(void)
+static void SetTradeSceneStrings(void)
 {
-    /*Gets the variable strings printed on the
+    /*Sets the variable strings printed on the
      *actual trading screen. For use in strings
      *like "[Pokemon] will be sent to [Trainer]."
      */

--- a/src/trade.c
+++ b/src/trade.c
@@ -207,7 +207,7 @@ static void sub_804E1DC(void);
 static void sub_804BBCC(void);
 static void sub_804D8E4(void);
 static void sub_804C164(void);
-static void sub_804C1A8(void);
+static void GetTradeSceneStrings(void);
 #ifdef NONMATCHING
 static
 #endif
@@ -4096,7 +4096,7 @@ static void sub_804B41C(void)
         case 11:
             sub_804BBE8(5);
             sub_804BBE8(0);
-            sub_804C1A8();
+            GetTradeSceneStrings();
             BeginNormalPaletteFade(-1, 0, 16, 0, 0);
             gMain.state ++;
             break;
@@ -4451,7 +4451,7 @@ static NAKED void sub_804B41C(void)
                     "\tbl sub_804BBE8\n"
                     "\tmovs r0, 0\n"
                     "\tbl sub_804BBE8\n"
-                    "\tbl sub_804C1A8\n"
+                    "\tbl GetTradeSceneStrings\n"
                     "\tmovs r0, 0x1\n"
                     "\tnegs r0, r0\n"
                     "\tmovs r1, 0\n"
@@ -4563,7 +4563,7 @@ void sub_804B790(void)
         case 11:
             sub_804BBE8(5);
             sub_804BBE8(0);
-            sub_804C1A8();
+            GetTradeSceneStrings();
             BeginNormalPaletteFade(-1, 0, 16, 0, 0);
             gMain.state ++;
             break;
@@ -4772,8 +4772,12 @@ static void sub_804C164(void)
     LoadSpritePalette(&gUnknown_082159B4);
 }
 
-static void sub_804C1A8(void)
+static void GetTradeSceneStrings(void)
 {
+    /*Gets the variable strings printed on the
+     *actual trading screen. For use in strings
+     *like "[Pokemon] will be sent to [Trainer]."
+     */
     u8 mpId;
     u8 string[20];
     const struct InGameTrade *ingameTrade;


### PR DESCRIPTION
sub_804C1A8() is responsible for getting the variable strings (like the trade partner's OTName, their Pokemon's nickname, and your Pokemon's nickname) needed to print the messages in the trade scene, so I renamed it to SetTradeSceneStrings(). Added a comment in the function to describe what it's doing as well.

Please let me know if this name isn't accurate enough or if my comment should be in a different style.