### PR TITLE
Fix "catching polymorphic type" errors with newest gcc

### DIFF
--- a/tools/preproc/asm_file.cpp
+++ b/tools/preproc/asm_file.cpp
@@ -266,7 +266,7 @@ int AsmFile::ReadString(unsigned char* s)
     {
         m_pos += stringParser.ParseString(m_pos, s, length);
     }
-    catch (std::runtime_error e)
+    catch (std::runtime_error& e)
     {
         RaiseError(e.what());
     }

--- a/tools/preproc/c_file.cpp
+++ b/tools/preproc/c_file.cpp
@@ -206,7 +206,7 @@ void CFile::TryConvertString()
             {
                 m_pos += stringParser.ParseString(m_pos, s, length);
             }
-            catch (std::runtime_error e)
+            catch (std::runtime_error& e)
             {
                 RaiseError(e.what());
             }


### PR DESCRIPTION
```
asm_file.cpp: In member function ‘int AsmFile::ReadString(unsigned char*)’:
asm_file.cpp:269:31: error: catching polymorphic type ‘class std::runtime_error’ by value [-Werror=catch-value=]
     catch (std::runtime_error e)
                               ^
cc1plus: all warnings being treated as errors
c_file.cpp: In member function ‘void CFile::TryConvertString()’:
c_file.cpp:209:39: error: catching polymorphic type ‘class std::runtime_error’ by value [-Werror=catch-value=]
             catch (std::runtime_error e)
                                       ^
cc1plus: all warnings being treated as errors
```

This prevents me from compiling pokeruby, it may not be a correct fix, but it works for me.