### PR TITLE
Add the .sgm file format to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ types_*.taghl
 *.s.old2
 *.dump
 *.sa*
+*.sgm
 Thumbs.db
 build/
 .idea/


### PR DESCRIPTION
This format represents VisualBoyAdvance's "save game" files. Since it's currently not being filtered out by .gitignore, this kind of files could be sent to a GitHub Repository via git push accidentally, which is why I suggest this change.