### PR TITLE
Revert migration to `colordiff` in asmdiff.sh

### DIFF
--- a/asmdiff.sh
+++ b/asmdiff.sh
@@ -4,4 +4,4 @@ OBJDUMP="$DEVKITARM/bin/arm-none-eabi-objdump -D -bbinary -marmv4t -Mforce-thumb
 OPTIONS="--start-address=$(($1)) --stop-address=$(($1 + $2))"
 $OBJDUMP $OPTIONS baserom.gba > baserom.dump
 $OBJDUMP $OPTIONS pokeruby.gba > pokeruby.dump
-colordiff -u baserom.dump pokeruby.dump
+diff -u baserom.dump pokeruby.dump


### PR DESCRIPTION
`colordiff` breaks output piping and invokes an additional dependency that no one needs