### PR TITLE
Fix misnamed Mossdeep Gym metatiles

### DIFF
--- a/data/maps/MossdeepCity_Gym/scripts.inc
+++ b/data/maps/MossdeepCity_Gym/scripts.inc
@@ -22,26 +22,26 @@ MossdeepCity_Gym_EventScript_15A506:: @ 815A506
 	end
 
 MossdeepCity_Gym_EventScript_15A510:: @ 815A510
-	setmetatile 5, 5, METATILE_MossdeepGym_Obelisk_Top, 0
-	setmetatile 2, 7, METATILE_MossdeepGym_Empty1, 1
+	setmetatile 5, 5, METATILE_MossdeepGym_RedArrow_Right, 0
+	setmetatile 2, 7, METATILE_MossdeepGym_Switch_Down, 1
 	goto MossdeepCity_Gym_EventScript_15A4E8
 	end
 
 MossdeepCity_Gym_EventScript_15A528:: @ 815A528
-	setmetatile 8, 14, METATILE_MossdeepGym_Obelisk_Top, 0
-	setmetatile 8, 10, METATILE_MossdeepGym_Empty1, 1
+	setmetatile 8, 14, METATILE_MossdeepGym_RedArrow_Right, 0
+	setmetatile 8, 10, METATILE_MossdeepGym_Switch_Down, 1
 	goto MossdeepCity_Gym_EventScript_15A4F7
 	end
 
 MossdeepCity_Gym_EventScript_15A540:: @ 815A540
-	setmetatile 15, 17, METATILE_MossdeepGym_Obelisk_Base, 0
-	setmetatile 17, 15, METATILE_MossdeepGym_Empty1, 1
+	setmetatile 15, 17, METATILE_MossdeepGym_RedArrow_Left, 0
+	setmetatile 17, 15, METATILE_MossdeepGym_Switch_Down, 1
 	goto MossdeepCity_Gym_EventScript_15A506
 	end
 
 MossdeepCity_Gym_EventScript_15A558:: @ 815A558
-	setmetatile 1, 23, METATILE_MossdeepGym_Wall_LeftCorner, 0
-	setmetatile 5, 24, METATILE_MossdeepGym_Empty1, 1
+	setmetatile 1, 23, METATILE_MossdeepGym_RedArrow_Up, 0
+	setmetatile 5, 24, METATILE_MossdeepGym_Switch_Down, 1
 	end
 
 MossdeepCity_Gym_EventScript_15A56B:: @ 815A56B
@@ -81,8 +81,8 @@ MossdeepCity_Gym_EventScript_15A5EA:: @ 815A5EA
 	setflag FLAG_MOSSDEEP_GYM_SWITCH_1
 	applymovement 255, MossdeepCity_Gym_Movement_15A7F7
 	waitmovement 0
-	setmetatile 5, 5, METATILE_MossdeepGym_Obelisk_Top, 0
-	setmetatile 2, 7, METATILE_MossdeepGym_Empty1, 1
+	setmetatile 5, 5, METATILE_MossdeepGym_RedArrow_Right, 0
+	setmetatile 2, 7, METATILE_MossdeepGym_Switch_Down, 1
 	goto MossdeepCity_Gym_EventScript_15A619
 	end
 
@@ -96,8 +96,8 @@ MossdeepCity_Gym_EventScript_15A621:: @ 815A621
 	clearflag FLAG_MOSSDEEP_GYM_SWITCH_1
 	applymovement 255, MossdeepCity_Gym_Movement_15A7F7
 	waitmovement 0
-	setmetatile 5, 5, METATILE_MossdeepGym_Obelisk_Base, 0
-	setmetatile 2, 7, METATILE_MossdeepGym_Empty0, 1
+	setmetatile 5, 5, METATILE_MossdeepGym_RedArrow_Left, 0
+	setmetatile 2, 7, METATILE_MossdeepGym_Switch_Up, 1
 	goto MossdeepCity_Gym_EventScript_15A619
 	end
 
@@ -107,8 +107,8 @@ MossdeepCity_Gym_EventScript_15A646:: @ 815A646
 	setflag FLAG_MOSSDEEP_GYM_SWITCH_2
 	applymovement 255, MossdeepCity_Gym_Movement_15A7F7
 	waitmovement 0
-	setmetatile 8, 14, METATILE_MossdeepGym_Obelisk_Top, 0
-	setmetatile 8, 10, METATILE_MossdeepGym_Empty1, 1
+	setmetatile 8, 14, METATILE_MossdeepGym_RedArrow_Right, 0
+	setmetatile 8, 10, METATILE_MossdeepGym_Switch_Down, 1
 	goto MossdeepCity_Gym_EventScript_15A619
 	end
 
@@ -116,8 +116,8 @@ MossdeepCity_Gym_EventScript_15A675:: @ 815A675
 	clearflag FLAG_MOSSDEEP_GYM_SWITCH_2
 	applymovement 255, MossdeepCity_Gym_Movement_15A7F7
 	waitmovement 0
-	setmetatile 8, 14, METATILE_MossdeepGym_OuterWall_RightCorner, 0
-	setmetatile 8, 10, METATILE_MossdeepGym_Empty0, 1
+	setmetatile 8, 14, METATILE_MossdeepGym_RedArrow_Down, 0
+	setmetatile 8, 10, METATILE_MossdeepGym_Switch_Up, 1
 	goto MossdeepCity_Gym_EventScript_15A619
 	end
 
@@ -127,8 +127,8 @@ MossdeepCity_Gym_EventScript_15A69A:: @ 815A69A
 	setflag FLAG_MOSSDEEP_GYM_SWITCH_3
 	applymovement 255, MossdeepCity_Gym_Movement_15A7F7
 	waitmovement 0
-	setmetatile 15, 17, METATILE_MossdeepGym_Obelisk_Base, 0
-	setmetatile 17, 15, METATILE_MossdeepGym_Empty1, 1
+	setmetatile 15, 17, METATILE_MossdeepGym_RedArrow_Left, 0
+	setmetatile 17, 15, METATILE_MossdeepGym_Switch_Down, 1
 	goto MossdeepCity_Gym_EventScript_15A619
 	end
 
@@ -136,8 +136,8 @@ MossdeepCity_Gym_EventScript_15A6C9:: @ 815A6C9
 	clearflag FLAG_MOSSDEEP_GYM_SWITCH_3
 	applymovement 255, MossdeepCity_Gym_Movement_15A7F7
 	waitmovement 0
-	setmetatile 15, 17, METATILE_MossdeepGym_Obelisk_Top, 0
-	setmetatile 17, 15, METATILE_MossdeepGym_Empty0, 1
+	setmetatile 15, 17, METATILE_MossdeepGym_RedArrow_Right, 0
+	setmetatile 17, 15, METATILE_MossdeepGym_Switch_Up, 1
 	goto MossdeepCity_Gym_EventScript_15A619
 	end
 
@@ -147,8 +147,8 @@ MossdeepCity_Gym_EventScript_15A6EE:: @ 815A6EE
 	setflag FLAG_MOSSDEEP_GYM_SWITCH_4
 	applymovement 255, MossdeepCity_Gym_Movement_15A7F7
 	waitmovement 0
-	setmetatile 1, 23, METATILE_MossdeepGym_Wall_LeftCorner, 0
-	setmetatile 5, 24, METATILE_MossdeepGym_Empty1, 1
+	setmetatile 1, 23, METATILE_MossdeepGym_RedArrow_Up, 0
+	setmetatile 5, 24, METATILE_MossdeepGym_Switch_Down, 1
 	goto MossdeepCity_Gym_EventScript_15A619
 	end
 
@@ -156,8 +156,8 @@ MossdeepCity_Gym_EventScript_15A71D:: @ 815A71D
 	clearflag FLAG_MOSSDEEP_GYM_SWITCH_4
 	applymovement 255, MossdeepCity_Gym_Movement_15A7F7
 	waitmovement 0
-	setmetatile 1, 23, METATILE_MossdeepGym_Obelisk_Top, 0
-	setmetatile 5, 24, METATILE_MossdeepGym_Empty0, 1
+	setmetatile 1, 23, METATILE_MossdeepGym_RedArrow_Right, 0
+	setmetatile 5, 24, METATILE_MossdeepGym_Switch_Up, 1
 	goto MossdeepCity_Gym_EventScript_15A619
 	end
 

--- a/include/constants/metatile_labels.h
+++ b/include/constants/metatile_labels.h
@@ -191,12 +191,12 @@
 #define METATILE_MauvilleGym_PoleBottom_Off  0x243
 
 // gTileset_MossdeepGym
-#define METATILE_MossdeepGym_Obelisk_Top           0x204
-#define METATILE_MossdeepGym_Obelisk_Base          0x20C
-#define METATILE_MossdeepGym_Wall_LeftCorner       0x20D
-#define METATILE_MossdeepGym_OuterWall_RightCorner 0x205
-#define METATILE_MossdeepGym_Empty0                0x238
-#define METATILE_MossdeepGym_Empty1                0x239
+#define METATILE_MossdeepGym_RedArrow_Right        0x204
+#define METATILE_MossdeepGym_RedArrow_Left         0x20C
+#define METATILE_MossdeepGym_RedArrow_Up           0x20D
+#define METATILE_MossdeepGym_RedArrow_Down         0x205
+#define METATILE_MossdeepGym_Switch_Up             0x238
+#define METATILE_MossdeepGym_Switch_Down           0x239
 
 // gTileset_Building
 #define METATILE_Building_TV_Off 0x002


### PR DESCRIPTION
These metatiles were misnamed in pokeemerald and then ported to pokeruby on the assumption they were from the Emerald `gTileset_MossdeepGym` and that the tileset was the same across versions. They're actually from the R/S version of the tileset, which was changed between versions. pokeemerald's misnamed versions of the metatiles will be updated in a later PR for gym scripts