### PR TITLE
Switch to pret short-types and tabs vs spaces

### DIFF
--- a/src/decompress.c
+++ b/src/decompress.c
@@ -112,146 +112,146 @@ void Unused_LZDecompressWramIndirect(const void **src, void *dest)
     LZ77UnCompWram(*src, dest);
 }
 
-void unref_sub_800D42C(int object_size, int object_count, unsigned char *src_tiles, unsigned char *dest_tiles)
+void unref_sub_800D42C(s32 object_size, s32 object_count, u8 *src_tiles, u8 *dest_tiles)
 {
-	/*
-	  This function appears to emulate behaviour found in the GB(C) versions regarding how the Pokemon images
-	  are stitched together to be displayed on the battle screen.
-	  Given "compacted" tiles, an object count and a bounding box/object size, place the tiles in such a way
-	  that the result will have each object centered in a 8x8 tile canvas.
-	*/
-	int i, j, k, l;
-	unsigned char *src = src_tiles, *dest = dest_tiles;
-	unsigned char bottom_off;
+    /*
+      This function appears to emulate behaviour found in the GB(C) versions regarding how the Pokemon images
+      are stitched together to be displayed on the battle screen.
+      Given "compacted" tiles, an object count and a bounding box/object size, place the tiles in such a way
+      that the result will have each object centered in a 8x8 tile canvas.
+    */
+    s32 i, j, k, l;
+    u8 *src = src_tiles, *dest = dest_tiles;
+    u8 bottom_off;
 
-	if (object_size & 1)
-	{
-		// Object size is odd
-		bottom_off = (object_size >> 1) + 4;
-		for (l = 0; l < object_count; l++)
-		{
-			// Clear all unused rows of tiles plus the half-tile required due to centering
-			for (j = 0; j < 8-object_size; j++)
-			{
-				for (k = 0; k < 8; k++)
-				{
-					for (i = 0; i < 16; i++)
-					{
-						if (j % 2 == 0)
-						{
-							// Clear top half of top tile and bottom half of bottom tile when on even j
-							((dest+i) + (k << 5))[((j >> 1) << 8)] = 0;
-							((bottom_off << 8) + (dest+i) + (k << 5) + 16)[((j >> 1) << 8)] = 0;
-						}
-						else
-						{
-							// Clear bottom half of top tile and top half of tile following bottom tile when on odd j
-							((dest+i) + (k << 5) + 16)[((j >> 1) << 8)] = 0;
-							((bottom_off << 8) + (dest+i) + (k << 5) + 256)[((j >> 1) << 8)] = 0;
-						}
-					}
-				}
-			}
+    if (object_size & 1)
+    {
+        // Object size is odd
+        bottom_off = (object_size >> 1) + 4;
+        for (l = 0; l < object_count; l++)
+        {
+            // Clear all unused rows of tiles plus the half-tile required due to centering
+            for (j = 0; j < 8-object_size; j++)
+            {
+                for (k = 0; k < 8; k++)
+                {
+                    for (i = 0; i < 16; i++)
+                    {
+                        if (j % 2 == 0)
+                        {
+                            // Clear top half of top tile and bottom half of bottom tile when on even j
+                            ((dest+i) + (k << 5))[((j >> 1) << 8)] = 0;
+                            ((bottom_off << 8) + (dest+i) + (k << 5) + 16)[((j >> 1) << 8)] = 0;
+                        }
+                        else
+                        {
+                            // Clear bottom half of top tile and top half of tile following bottom tile when on odd j
+                            ((dest+i) + (k << 5) + 16)[((j >> 1) << 8)] = 0;
+                            ((bottom_off << 8) + (dest+i) + (k << 5) + 256)[((j >> 1) << 8)] = 0;
+                        }
+                    }
+                }
+            }
 
-			// Clear the columns to the left and right that wont be used completely
-			// Unlike the previous loops, this will clear the later used space as well
-			for (j = 0; j < 2; j++)
-			{
-				for (i = 0; i < 8; i++)
-				{
-					for (k = 0; k < 32; k++)
-					{
-						// Left side
-						((dest+k) + (i << 8))[(j << 5)] = 0;
-						// Right side
-						((dest+k) + (i << 8))[(j << 5)+192] = 0;
-					}
-				}
-			}
+            // Clear the columns to the left and right that wont be used completely
+            // Unlike the previous loops, this will clear the later used space as well
+            for (j = 0; j < 2; j++)
+            {
+                for (i = 0; i < 8; i++)
+                {
+                    for (k = 0; k < 32; k++)
+                    {
+                        // Left side
+                        ((dest+k) + (i << 8))[(j << 5)] = 0;
+                        // Right side
+                        ((dest+k) + (i << 8))[(j << 5)+192] = 0;
+                    }
+                }
+            }
 
-			// Skip the top row and first tile on the second row for objects of size 5
-			if (object_size == 5) dest += 0x120;
+            // Skip the top row and first tile on the second row for objects of size 5
+            if (object_size == 5) dest += 0x120;
 
-			// Copy tile data
-			for (j = 0; j < object_size; j++)
-			{
-				for (k = 0; k < object_size; k++)
-				{
-					for (i = 0; i < 4; i++)
-					{
-						// Offset the tile by +4px in both x and y directions
-						(dest + (i << 2))[18] = (src + (i << 2))[0];
-						(dest + (i << 2))[19] = (src + (i << 2))[1];
-						(dest + (i << 2))[48] = (src + (i << 2))[2];
-						(dest + (i << 2))[49] = (src + (i << 2))[3];
+            // Copy tile data
+            for (j = 0; j < object_size; j++)
+            {
+                for (k = 0; k < object_size; k++)
+                {
+                    for (i = 0; i < 4; i++)
+                    {
+                        // Offset the tile by +4px in both x and y directions
+                        (dest + (i << 2))[18] = (src + (i << 2))[0];
+                        (dest + (i << 2))[19] = (src + (i << 2))[1];
+                        (dest + (i << 2))[48] = (src + (i << 2))[2];
+                        (dest + (i << 2))[49] = (src + (i << 2))[3];
 
-						(dest + (i << 2))[258] = (src + (i << 2))[16];
-						(dest + (i << 2))[259] = (src + (i << 2))[17];
-						(dest + (i << 2))[288] = (src + (i << 2))[18];
-						(dest + (i << 2))[289] = (src + (i << 2))[19];
-					}
-					src += 32;
-					dest += 32;
-				}
+                        (dest + (i << 2))[258] = (src + (i << 2))[16];
+                        (dest + (i << 2))[259] = (src + (i << 2))[17];
+                        (dest + (i << 2))[288] = (src + (i << 2))[18];
+                        (dest + (i << 2))[289] = (src + (i << 2))[19];
+                    }
+                    src += 32;
+                    dest += 32;
+                }
 
-				// At the end of a row, skip enough tiles to get to the beginning of the next row
-				if (object_size == 7) dest += 0x20;
-				else if (object_size == 5) dest += 0x60;
-			}
+                // At the end of a row, skip enough tiles to get to the beginning of the next row
+                if (object_size == 7) dest += 0x20;
+                else if (object_size == 5) dest += 0x60;
+            }
 
-			// Skip remaining unused space to go to the beginning of the next object
-			if (object_size == 7) dest += 0x100;
-			else if (object_size == 5) dest += 0x1e0;
-		}
-	}
-	else
-	{
-		// Object size is even
-		for (i = 0; i < object_count; i++)
-		{
-			// For objects of size 6, the first and last row and column will be cleared
-			// While the remaining space will be filled with actual data
-			if (object_size == 6)
-			{
-				for (k = 0; k < 256; k++) {
-					*dest = 0;
-					dest++;
-				}
-			}
+            // Skip remaining unused space to go to the beginning of the next object
+            if (object_size == 7) dest += 0x100;
+            else if (object_size == 5) dest += 0x1e0;
+        }
+    }
+    else
+    {
+        // Object size is even
+        for (i = 0; i < object_count; i++)
+        {
+            // For objects of size 6, the first and last row and column will be cleared
+            // While the remaining space will be filled with actual data
+            if (object_size == 6)
+            {
+                for (k = 0; k < 256; k++) {
+                    *dest = 0;
+                    dest++;
+                }
+            }
 
-			for (j = 0; j < object_size; j++)
-			{
-				if (object_size == 6)
-				{
-					for (k = 0; k < 32; k++) {
-						*dest = 0;
-						dest++;
-					}
-				}
+            for (j = 0; j < object_size; j++)
+            {
+                if (object_size == 6)
+                {
+                    for (k = 0; k < 32; k++) {
+                        *dest = 0;
+                        dest++;
+                    }
+                }
 
-				// Copy tile data
-				for (k = 0; k < 32 * object_size; k++) {
-					*dest = *src;
-					src++;
-					dest++;
-				}
+                // Copy tile data
+                for (k = 0; k < 32 * object_size; k++) {
+                    *dest = *src;
+                    src++;
+                    dest++;
+                }
 
-				if (object_size == 6)
-				{
-					for (k = 0; k < 32; k++) {
-						*dest = 0;
-						dest++;
-					}
-				}
-			}
+                if (object_size == 6)
+                {
+                    for (k = 0; k < 32; k++) {
+                        *dest = 0;
+                        dest++;
+                    }
+                }
+            }
 
-			if (object_size == 6)
-			{
-				for (k = 0; k < 256; k++) {
-					*dest = 0;
-					dest++;
-				}
-			}
-		}
-	}
+            if (object_size == 6)
+            {
+                for (k = 0; k < 256; k++) {
+                    *dest = 0;
+                    dest++;
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
As per the comment [over at pokeemerald](https://github.com/pret/pokeemerald/pull/1052#issuecomment-631758622) switch indentation to 4 spaces and change types to use the repo-wide shorter versions