### PR TITLE
More simple NONMATCHING fixes:

### DIFF
--- a/src/battle/anim/shadow_minimize.c
+++ b/src/battle/anim/shadow_minimize.c
@@ -119,7 +119,7 @@ void CreateMinimizeSprite(struct Task* task, u8 taskId)
             gSprites[spriteId].subpriority = task->data[7] - task->data[3];
             task->data[3]++;
             task->data[6]++;
-            gSprites[spriteId].data[0] = 16; 
+            gSprites[spriteId].data[0] = 16;
             gSprites[spriteId].data[1] = taskId;
             gSprites[spriteId].data[2] = 6;
             gSprites[spriteId].callback = ClonedMinimizeSprite_Step;

--- a/src/battle/anim/unused_9.c
+++ b/src/battle/anim/unused_9.c
@@ -33,7 +33,6 @@ void sub_80CFDFC(struct Sprite* sprite)
     sprite->callback = sub_80CFE2C;
 }
 
-#ifdef NONMATCHING
 static void sub_80CFE2C(struct Sprite* sprite)
 {
     u16 r7;
@@ -44,9 +43,9 @@ static void sub_80CFE2C(struct Sprite* sprite)
         sprite->data[1] = 0;
         r5 = sprite->data[0];
         r7 = gPlttBufferFaded[r5 + 8];
-        for (i = 0; i < 8; i++)
+        for (i = 8; i < 16; i++)
         {
-            gPlttBufferFaded[r5 + i + 8] = gPlttBufferFaded[r5 + i + 9];
+            gPlttBufferFaded[r5 + i] = gPlttBufferFaded[r5 + i + 1];
         }
         gPlttBufferFaded[r5 + 15] = r7;
 
@@ -54,67 +53,3 @@ static void sub_80CFE2C(struct Sprite* sprite)
             DestroyAnimSprite(sprite);
     }
 }
-#else
-NAKED
-static void sub_80CFE2C(struct Sprite* sprite)
-{
-    asm(".syntax unified\n\
-    push {r4-r7,lr}\n\
-	adds r4, r0, 0\n\
-	ldrh r0, [r4, 0x30]\n\
-	adds r0, 0x1\n\
-	strh r0, [r4, 0x30]\n\
-	lsls r0, 16\n\
-	asrs r0, 16\n\
-	cmp r0, 0x2\n\
-	bne _080CFE90\n\
-	movs r0, 0\n\
-	strh r0, [r4, 0x30]\n\
-	ldrh r5, [r4, 0x2E]\n\
-	ldr r1, _080CFE98 @ =gPlttBufferFaded\n\
-	adds r0, r5, 0\n\
-	adds r0, 0x8\n\
-	lsls r0, 1\n\
-	adds r0, r1\n\
-	ldrh r7, [r0]\n\
-	adds r6, r1, 0 @puts gPlttBufferFaded in r6\n\
-	adds r1, r5, 0\n\
-	adds r1, 0x9\n\
-	lsls r0, r5, 1\n\
-	adds r0, r6 \n\
-	adds r2, r0, 0\n\
-	adds r2, 0x10\n\
-	movs r3, 0x7\n\
-	lsls r1, 1\n\
-	adds r1, r6 \n\
-_080CFE64:\n\
-	ldrh r0, [r1]\n\
-	strh r0, [r2]\n\
-	adds r1, 0x2\n\
-	adds r2, 0x2\n\
-	subs r3, 0x1\n\
-	cmp r3, 0\n\
-	bge _080CFE64\n\
-	adds r0, r5, 0\n\
-	adds r0, 0xF\n\
-	lsls r0, 1\n\
-	adds r0, r6\n\
-	strh r7, [r0]\n\
-	ldrh r0, [r4, 0x32]\n\
-	adds r0, 0x1\n\
-	strh r0, [r4, 0x32]\n\
-	lsls r0, 16\n\
-	asrs r0, 16\n\
-	cmp r0, 0x18\n\
-	bne _080CFE90\n\
-	adds r0, r4, 0\n\
-	bl DestroyAnimSprite\n\
-_080CFE90:\n\
-	pop {r4-r7}\n\
-	pop {r0}\n\
-	bx r0\n\
-	.align 2, 0\n\
-_080CFE98: .4byte gPlttBufferFaded\n\
-.syntax divided\n");
-}
-#endif

--- a/src/field_effect_helpers.c
+++ b/src/field_effect_helpers.c
@@ -1009,19 +1009,19 @@ static void sub_8127FD4(struct ObjectEvent *objectEvent, struct Sprite *sprite)
         StartSpriteAnimIfDifferent(sprite, surfBlobDirectionAnims[objectEvent->movementDirection]);
 }
 
-#ifdef NONMATCHING
 static void sub_812800C(struct ObjectEvent *objectEvent, struct Sprite *sprite)
 {
-    s16 x;
-    s16 y;
     u8 i;
+    s16 x = objectEvent->currentCoords.x;
+    s16 y = objectEvent->currentCoords.y;
+    s32 spriteY = sprite->pos2.y;
 
-    x = objectEvent->currentCoords.x;
-    y = objectEvent->currentCoords.y;
-    if (sprite->pos2.y == 0 && (x != sprite->data[6] || y != sprite->data[7]))
+    if (spriteY == 0 && (x != sprite->data[6] || y != sprite->data[7]))
     {
-        sprite->data[5] = sprite->pos2.y;
-        for (sprite->data[6] = x, sprite->data[7] = y, i = DIR_SOUTH; i <= DIR_EAST; i ++, x = sprite->data[6], y = sprite->data[7])
+        sprite->data[5] = spriteY;
+        sprite->data[6] = x;
+        sprite->data[7] = y;
+        for (i = DIR_SOUTH; i <= DIR_EAST; i++, x = sprite->data[6], y = sprite->data[7])
         {
             MoveCoords(i, &x, &y);
             if (MapGridGetZCoordAt(x, y) == 3)
@@ -1032,87 +1032,6 @@ static void sub_812800C(struct ObjectEvent *objectEvent, struct Sprite *sprite)
         }
     }
 }
-#else
-NAKED static void sub_812800C(struct ObjectEvent *objectEvent, struct Sprite *sprite)
-{
-    asm_unified("\tpush {r4-r7,lr}\n"
-                    "\tmov r7, r8\n"
-                    "\tpush {r7}\n"
-                    "\tsub sp, 0x4\n"
-                    "\tadds r4, r1, 0\n"
-                    "\tldrh r2, [r0, 0x10]\n"
-                    "\tmov r1, sp\n"
-                    "\tstrh r2, [r1]\n"
-                    "\tldrh r1, [r0, 0x12]\n"
-                    "\tmov r0, sp\n"
-                    "\tadds r0, 0x2\n"
-                    "\tstrh r1, [r0]\n"
-                    "\tmovs r2, 0x26\n"
-                    "\tldrsh r3, [r4, r2]\n"
-                    "\tmov r8, r0\n"
-                    "\tcmp r3, 0\n"
-                    "\tbne _08128094\n"
-                    "\tmov r0, sp\n"
-                    "\tmovs r5, 0\n"
-                    "\tldrsh r2, [r0, r5]\n"
-                    "\tmovs r5, 0x3A\n"
-                    "\tldrsh r0, [r4, r5]\n"
-                    "\tcmp r2, r0\n"
-                    "\tbne _08128048\n"
-                    "\tlsls r0, r1, 16\n"
-                    "\tasrs r0, 16\n"
-                    "\tmovs r5, 0x3C\n"
-                    "\tldrsh r1, [r4, r5]\n"
-                    "\tcmp r0, r1\n"
-                    "\tbeq _08128094\n"
-                    "_08128048:\n"
-                    "\tstrh r3, [r4, 0x38]\n"
-                    "\tstrh r2, [r4, 0x3A]\n"
-                    "\tmov r1, r8\n"
-                    "\tmovs r2, 0\n"
-                    "\tldrsh r0, [r1, r2]\n"
-                    "\tstrh r0, [r4, 0x3C]\n"
-                    "\tmovs r5, 0x1\n"
-                    "\tmov r7, r8\n"
-                    "\tmov r6, sp\n"
-                    "_0812805A:\n"
-                    "\tadds r0, r5, 0\n"
-                    "\tmov r1, sp\n"
-                    "\tadds r2, r7, 0\n"
-                    "\tbl MoveCoords\n"
-                    "\tmovs r1, 0\n"
-                    "\tldrsh r0, [r6, r1]\n"
-                    "\tmovs r2, 0\n"
-                    "\tldrsh r1, [r7, r2]\n"
-                    "\tbl MapGridGetZCoordAt\n"
-                    "\tlsls r0, 24\n"
-                    "\tlsrs r0, 24\n"
-                    "\tcmp r0, 0x3\n"
-                    "\tbne _08128080\n"
-                    "\tldrh r0, [r4, 0x38]\n"
-                    "\tadds r0, 0x1\n"
-                    "\tstrh r0, [r4, 0x38]\n"
-                    "\tb _08128094\n"
-                    "_08128080:\n"
-                    "\tadds r0, r5, 0x1\n"
-                    "\tlsls r0, 24\n"
-                    "\tlsrs r5, r0, 24\n"
-                    "\tldrh r0, [r4, 0x3A]\n"
-                    "\tstrh r0, [r6]\n"
-                    "\tldrh r0, [r4, 0x3C]\n"
-                    "\tmov r1, r8\n"
-                    "\tstrh r0, [r1]\n"
-                    "\tcmp r5, 0x4\n"
-                    "\tbls _0812805A\n"
-                    "_08128094:\n"
-                    "\tadd sp, 0x4\n"
-                    "\tpop {r3}\n"
-                    "\tmov r8, r3\n"
-                    "\tpop {r4-r7}\n"
-                    "\tpop {r0}\n"
-                    "\tbx r0");
-}
-#endif
 
 static void sub_81280A0(struct ObjectEvent *objectEvent, struct Sprite *linkedSprite, struct Sprite *sprite)
 {
@@ -1453,152 +1372,35 @@ void WaitFieldEffectSpriteAnim(struct Sprite *sprite)
         UpdateObjectEventSpriteVisibility(sprite, FALSE);
 }
 
-#ifdef NONMATCHING
 static void sub_812882C(struct Sprite *sprite /*r6*/, u8 z, u8 offset)
 {
     u8 i;
-    s16 xlo;
-    s16 xhi;
-    s16 lx;
-    s16 lyhi;
-    s16 ly;
-    s16 ylo;
-    s16 yhi;
-    struct ObjectEvent *objectEvent; // r4
-    const struct ObjectEventGraphicsInfo *graphicsInfo; // destroyed
-    struct Sprite *linkedSprite; // r5
+    s16 var, xhi, lyhi, yhi, ylo;
+    const struct ObjectEventGraphicsInfo *graphicsInfo; // Unused Variable
+    struct Sprite *linkedSprite;
 
     SetObjectSubpriorityByZCoord(z, sprite, offset);
-    for (i = 0; i < 16; i ++)
+    for (i = 0; i < OBJECT_EVENTS_COUNT; i ++)
     {
-        objectEvent = &gObjectEvents[i];
+        struct ObjectEvent *objectEvent = &gObjectEvents[i];
         if (objectEvent->active)
         {
             graphicsInfo = GetObjectEventGraphicsInfo(objectEvent->graphicsId);
             linkedSprite = &gSprites[objectEvent->spriteId];
             xhi = sprite->pos1.x + sprite->centerToCornerVecX;
-            xlo = sprite->pos1.x - sprite->centerToCornerVecX;
-            lx = linkedSprite->pos1.x;
-            if (xhi < lx && xlo > lx)
+            var = sprite->pos1.x - sprite->centerToCornerVecX;
+            if (xhi < linkedSprite->pos1.x && var > linkedSprite->pos1.x)
             {
                 lyhi = linkedSprite->pos1.y + linkedSprite->centerToCornerVecY;
-                ly = linkedSprite->pos1.y;
+                var = linkedSprite->pos1.y;
                 ylo = sprite->pos1.y - sprite->centerToCornerVecY;
                 yhi = ylo + linkedSprite->centerToCornerVecY;
-                if ((lyhi < yhi || lyhi < ylo) && ly > yhi)
+                if ((lyhi < yhi || lyhi < ylo) && var > yhi && sprite->subpriority <= linkedSprite->subpriority)
                 {
-                    if (sprite->subpriority <= linkedSprite->subpriority)
-                    {
-                        sprite->subpriority = linkedSprite->subpriority + 2;
-                        break;
-                    }
+                    sprite->subpriority = linkedSprite->subpriority + 2;
+                    break;
                 }
             }
         }
     }
 }
-#else
-NAKED static void sub_812882C(struct Sprite *sprite /*r6*/, u8 z, u8 offset)
-{
-    asm_unified("\tpush {r4-r7,lr}\n"
-                    "\tadds r6, r0, 0\n"
-                    "\tadds r0, r1, 0\n"
-                    "\tlsls r0, 24\n"
-                    "\tlsrs r0, 24\n"
-                    "\tlsls r2, 24\n"
-                    "\tlsrs r2, 24\n"
-                    "\tadds r1, r6, 0\n"
-                    "\tbl SetObjectSubpriorityByZCoord\n"
-                    "\tmovs r7, 0\n"
-                    "_08128842:\n"
-                    "\tlsls r0, r7, 3\n"
-                    "\tadds r0, r7\n"
-                    "\tlsls r0, 2\n"
-                    "\tldr r1, _081288DC @ =gObjectEvents\n"
-                    "\tadds r4, r0, r1\n"
-                    "\tldrb r0, [r4]\n"
-                    "\tlsls r0, 31\n"
-                    "\tcmp r0, 0\n"
-                    "\tbeq _081288E4\n"
-                    "\tldrb r0, [r4, 0x5]\n"
-                    "\tbl GetObjectEventGraphicsInfo\n"
-                    "\tldrb r1, [r4, 0x4]\n"
-                    "\tlsls r0, r1, 4\n"
-                    "\tadds r0, r1\n"
-                    "\tlsls r0, 2\n"
-                    "\tldr r1, _081288E0 @ =gSprites\n"
-                    "\tadds r5, r0, r1\n"
-                    "\tadds r0, r6, 0\n"
-                    "\tadds r0, 0x28\n"
-                    "\tmovs r2, 0\n"
-                    "\tldrsb r2, [r0, r2]\n"
-                    "\tldrh r0, [r6, 0x20]\n"
-                    "\tadds r1, r0, r2\n"
-                    "\tsubs r0, r2\n"
-                    "\tlsls r0, 16\n"
-                    "\tlsrs r4, r0, 16\n"
-                    "\tlsls r1, 16\n"
-                    "\tasrs r1, 16\n"
-                    "\tmovs r0, 0x20\n"
-                    "\tldrsh r2, [r5, r0]\n"
-                    "\tcmp r1, r2\n"
-                    "\tbge _081288E4\n"
-                    "\tlsls r0, r4, 16\n"
-                    "\tasrs r0, 16\n"
-                    "\tcmp r0, r2\n"
-                    "\tble _081288E4\n"
-                    "\tadds r0, r5, 0\n"
-                    "\tadds r0, 0x29\n"
-                    "\tmovs r3, 0\n"
-                    "\tldrsb r3, [r0, r3]\n"
-                    "\tldrh r2, [r5, 0x22]\n"
-                    "\tadds r2, r3\n"
-                    "\tldrh r4, [r5, 0x22]\n"
-                    "\tadds r0, r6, 0\n"
-                    "\tadds r0, 0x29\n"
-                    "\tmovs r1, 0\n"
-                    "\tldrsb r1, [r0, r1]\n"
-                    "\tldrh r0, [r6, 0x22]\n"
-                    "\tsubs r0, r1\n"
-                    "\tlsls r0, 16\n"
-                    "\tasrs r0, 16\n"
-                    "\tadds r3, r0, r3\n"
-                    "\tlsls r2, 16\n"
-                    "\tasrs r2, 16\n"
-                    "\tlsls r3, 16\n"
-                    "\tasrs r3, 16\n"
-                    "\tcmp r2, r3\n"
-                    "\tblt _081288BC\n"
-                    "\tcmp r2, r0\n"
-                    "\tbge _081288E4\n"
-                    "_081288BC:\n"
-                    "\tlsls r0, r4, 16\n"
-                    "\tasrs r0, 16\n"
-                    "\tcmp r0, r3\n"
-                    "\tble _081288E4\n"
-                    "\tadds r2, r6, 0\n"
-                    "\tadds r2, 0x43\n"
-                    "\tadds r0, r5, 0\n"
-                    "\tadds r0, 0x43\n"
-                    "\tldrb r1, [r0]\n"
-                    "\tldrb r0, [r2]\n"
-                    "\tcmp r0, r1\n"
-                    "\tbhi _081288E4\n"
-                    "\tadds r0, r1, 0x2\n"
-                    "\tstrb r0, [r2]\n"
-                    "\tb _081288EE\n"
-                    "\t.align 2, 0\n"
-                    "_081288DC: .4byte gObjectEvents\n"
-                    "_081288E0: .4byte gSprites\n"
-                    "_081288E4:\n"
-                    "\tadds r0, r7, 0x1\n"
-                    "\tlsls r0, 24\n"
-                    "\tlsrs r7, r0, 24\n"
-                    "\tcmp r7, 0xF\n"
-                    "\tbls _08128842\n"
-                    "_081288EE:\n"
-                    "\tpop {r4-r7}\n"
-                    "\tpop {r0}\n"
-                    "\tbx r0");
-}
-#endif

--- a/src/tv.c
+++ b/src/tv.c
@@ -2366,11 +2366,12 @@ s8 sub_80C019C(TVShow tvShows[])
     return -1;
 }
 
-#ifdef NONMATCHING
 void sub_80C01D4(void)
 {
     u16 i;
-    for (i=0; i<24; i++)
+    u16 j;
+
+    for (i = 0; i < 24; i++)
     {
         switch (gSaveBlock1.tvShows[i].common.kind)
         {
@@ -2380,251 +2381,58 @@ void sub_80C01D4(void)
             case TVSHOW_MASS_OUTBREAK:
                 break;
             case TVSHOW_FAN_CLUB_LETTER:
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->fanclubLetter.species, i);
+                j = (&gSaveBlock1.tvShows[i])->fanclubLetter.species;
+                sub_80C03C8(j, i);
                 break;
             case TVSHOW_PKMN_FAN_CLUB_OPINIONS:
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->fanclubOpinions.var02, i);
+                j = (&gSaveBlock1.tvShows[i])->fanclubOpinions.var02;
+                sub_80C03C8(j, i);
                 break;
             case TVSHOW_UNKN_SHOWTYPE_04:
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->unkShow04.var06, i);
+                j = (&gSaveBlock1.tvShows[i])->unkShow04.var06;
+                sub_80C03C8(j, i);
                 break;
             case TVSHOW_NAME_RATER_SHOW:
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->nameRaterShow.species, i);
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->nameRaterShow.var1C, i);
+                j = (&gSaveBlock1.tvShows[i])->nameRaterShow.species;
+                sub_80C03C8(j, i);
+                j = (&gSaveBlock1.tvShows[i])->nameRaterShow.var1C;
+                sub_80C03C8(j, i);
                 break;
             case TVSHOW_BRAVO_TRAINER_POKEMON_PROFILE:
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->bravoTrainer.species, i);
+                j = (&gSaveBlock1.tvShows[i])->bravoTrainer.species;
+                sub_80C03C8(j, i);
                 break;
             case TVSHOW_BRAVO_TRAINER_BATTLE_TOWER_PROFILE:
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->bravoTrainerTower.species, i);
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->bravoTrainerTower.defeatedSpecies, i);
+                j = (&gSaveBlock1.tvShows[i])->bravoTrainerTower.species;
+                sub_80C03C8(j, i);
+                j = (&gSaveBlock1.tvShows[i])->bravoTrainerTower.defeatedSpecies;
+                sub_80C03C8(j, i);
                 break;
             case TVSHOW_POKEMON_TODAY_CAUGHT:
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->pokemonToday.species, i);
+                j = (&gSaveBlock1.tvShows[i])->pokemonToday.species;
+                sub_80C03C8(j, i);
                 break;
             case TVSHOW_POKEMON_TODAY_FAILED:
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->pokemonTodayFailed.species, i);
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->pokemonTodayFailed.species2, i);
+                j = (&gSaveBlock1.tvShows[i])->pokemonTodayFailed.species;
+                sub_80C03C8(j, i);
+                j = (&gSaveBlock1.tvShows[i])->pokemonTodayFailed.species2;
+                sub_80C03C8(j, i);
                 break;
             case TVSHOW_FISHING_ADVICE:
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->pokemonAngler.var04, i);
+                j = (&gSaveBlock1.tvShows[i])->pokemonAngler.var04;
+                sub_80C03C8(j, i);
                 break;
             case TVSHOW_WORLD_OF_MASTERS:
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->worldOfMasters.var08, i);
-                sub_80C03C8((&gSaveBlock1.tvShows[i])->worldOfMasters.var04, i);
+                j = (&gSaveBlock1.tvShows[i])->worldOfMasters.var08;
+                sub_80C03C8(j, i);
+                j = (&gSaveBlock1.tvShows[i])->worldOfMasters.var04;
+                sub_80C03C8(j, i);
                 break;
             default:
                 sub_80C03A8(i);
         }
     }
 }
-#else
-NAKED
-void sub_80C01D4(void) {
-    asm(".syntax unified\n\
-    push {r4-r6,lr}\n\
-    movs r6, 0\n\
-_080C01D8:\n\
-    ldr r0, _080C01F8 @ =gSaveBlock1\n\
-    lsls r2, r6, 3\n\
-    adds r1, r2, r6\n\
-    lsls r1, 2\n\
-    adds r1, r0\n\
-    ldr r0, _080C01FC @ =0x00002738\n\
-    adds r1, r0\n\
-    ldrb r0, [r1]\n\
-    cmp r0, 0x29\n\
-    bls _080C01EE\n\
-    b _default\n\
-_080C01EE:\n\
-    lsls r0, 2\n\
-    ldr r1, _080C0200 @ =_080C0204\n\
-    adds r0, r1\n\
-    ldr r0, [r0]\n\
-    mov pc, r0\n\
-    .align 2, 0\n\
-_080C01F8: .4byte gSaveBlock1\n\
-_080C01FC: .4byte 0x00002738\n\
-_080C0200: .4byte _080C0204\n\
-    .align 2, 0\n\
-_080C0204:\n\
-    .4byte _break\n\
-    .4byte _fanclubLetter @ TVSHOW_FAN_CLUB_LETTER\n\
-    .4byte _break    @ TVSHOW_RECENT_HAPPENINGS\n\
-    .4byte _fanclubOpinions @ TVSHOW_PKMN_FAN_CLUB_OPINIONS\n\
-    .4byte _showtype4 @ TVSHOW_UNKN_SHOWTYPE_04\n\
-    .4byte _nameRater @ TVSHOW_NAME_RATER_SHOW\n\
-    .4byte _bravoTrainerContest @ TVSHOW_BRAVO_TRAINER_POKEMON_PROFILE\n\
-    .4byte _bravoTrainerTower @ TVSHOW_BRAVO_TRAINER_BATTLE_TOWER_PROFILE\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _pokemonTodayS @ TVSHOW_POKEMON_TODAY_CAUGHT\n\
-    .4byte _break    @ TVSHOW_SMART_SHOPPER\n\
-    .4byte _pokemonTodayF @ TVSHOW_POKEMON_TODAY_FAILED\n\
-    .4byte _fishing @ TVSHOW_FISHING_ADVICE\n\
-    .4byte _worldOfMasters @ TVSHOW_WORLD_OF_MASTERS\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _default\n\
-    .4byte _break    @ TVSHOW_MASS_OUTBREAK\n\
-_fanclubLetter:\n\
-    adds r0, r2, r6\n\
-    lsls r0, 2\n\
-    ldr r1, _080C02B8 @ =gSaveBlock1 + 0x2738\n\
-    adds r0, r1\n\
-    ldrh r0, [r0, 0x2]\n\
-    b _checkSpecies1 @ sub_80C03C8(r0, i)\n\
-    .align 2, 0\n\
-_080C02B8: .4byte gSaveBlock1 + 0x2738\n\
-_fanclubOpinions:\n\
-    adds r0, r2, r6\n\
-    lsls r0, 2\n\
-    ldr r1, _080C02C8 @ =gSaveBlock1 + 0x2738\n\
-    adds r0, r1\n\
-    ldrh r0, [r0, 0x2]\n\
-    b _checkSpecies1 @ sub_80C03C8(r0, i)\n\
-    .align 2, 0\n\
-_080C02C8: .4byte gSaveBlock1 + 0x2738\n\
-_showtype4:\n\
-    adds r0, r2, r6\n\
-    lsls r0, 2\n\
-    ldr r1, _080C02D8 @ =gSaveBlock1 + 0x2738\n\
-    adds r0, r1\n\
-    ldrh r0, [r0, 0x6]\n\
-    b _checkSpecies1 @ sub_80C03C8(r0, i)\n\
-    .align 2, 0\n\
-_080C02D8: .4byte gSaveBlock1 + 0x2738\n\
-_nameRater:\n\
-    adds r4, r2, r6\n\
-    lsls r4, 2\n\
-    ldr r0, _080C02F4 @ =gSaveBlock1 + 0x2738\n\
-    adds r4, r0\n\
-    ldrh r0, [r4, 0x2]\n\
-    lsls r5, r6, 24\n\
-    lsrs r5, 24\n\
-    adds r1, r5, 0\n\
-    bl sub_80C03C8\n\
-    ldrh r0, [r4, 0x1C]\n\
-    b _checkSpecies2 @ sub_80C03C8(r0, i)\n\
-    .align 2, 0\n\
-_080C02F4: .4byte gSaveBlock1 + 0x2738\n\
-_bravoTrainerContest:\n\
-    adds r0, r2, r6\n\
-    lsls r0, 2\n\
-    ldr r1, _080C0304 @ =gSaveBlock1 + 0x2738\n\
-    adds r0, r1\n\
-    ldrh r0, [r0, 0x2]\n\
-    b _checkSpecies1 @ sub_80C03C8(r0, i)\n\
-    .align 2, 0\n\
-_080C0304: .4byte gSaveBlock1 + 0x2738\n\
-_bravoTrainerTower:\n\
-    adds r4, r2, r6\n\
-    lsls r4, 2\n\
-    ldr r0, _080C0320 @ =gSaveBlock1 + 0x2738\n\
-    adds r4, r0\n\
-    ldrh r0, [r4, 0xA]\n\
-    lsls r5, r6, 24\n\
-    lsrs r5, 24\n\
-    adds r1, r5, 0\n\
-    bl sub_80C03C8\n\
-    ldrh r0, [r4, 0x14]\n\
-    b _checkSpecies2 @ sub_80C03C8(r0, i)\n\
-    .align 2, 0\n\
-_080C0320: .4byte gSaveBlock1 + 0x2738\n\
-_pokemonTodayS:\n\
-    adds r0, r2, r6\n\
-    lsls r0, 2\n\
-    ldr r1, _080C0330 @ =gSaveBlock1 + 0x2738\n\
-    adds r0, r1\n\
-    ldrh r0, [r0, 0x10]\n\
-    b _checkSpecies1 @ sub_80C03C8(r0, i)\n\
-    .align 2, 0\n\
-_080C0330: .4byte gSaveBlock1 + 0x2738\n\
-_pokemonTodayF:\n\
-    adds r4, r2, r6\n\
-    lsls r4, 2\n\
-    ldr r0, _080C034C @ =gSaveBlock1 + 0x2738\n\
-    adds r4, r0\n\
-    ldrh r0, [r4, 0xC]\n\
-    lsls r5, r6, 24\n\
-    lsrs r5, 24\n\
-    adds r1, r5, 0\n\
-    bl sub_80C03C8\n\
-    ldrh r0, [r4, 0xE]\n\
-    b _checkSpecies2 @ sub_80C03C8(r0, i)\n\
-    .align 2, 0\n\
-_080C034C: .4byte gSaveBlock1 + 0x2738\n\
-_fishing:\n\
-    adds r0, r2, r6\n\
-    lsls r0, 2\n\
-    ldr r1, _080C0364 @ =gSaveBlock1 + 0x2738\n\
-    adds r0, r1\n\
-    ldrh r0, [r0, 0x4]\n\
-_checkSpecies1:\n\
-    lsls r1, r6, 24\n\
-    lsrs r1, 24\n\
-    bl sub_80C03C8\n\
-    b _break\n\
-    .align 2, 0\n\
-_080C0364: .4byte gSaveBlock1 + 0x2738\n\
-_worldOfMasters:\n\
-    adds r4, r2, r6\n\
-    lsls r4, 2\n\
-    ldr r0, _080C0388 @ =gSaveBlock1 + 0x2738\n\
-    adds r4, r0\n\
-    ldrh r0, [r4, 0x8]\n\
-    lsls r5, r6, 24\n\
-    lsrs r5, 24\n\
-    adds r1, r5, 0\n\
-    bl sub_80C03C8\n\
-    ldrh r0, [r4, 0x4]\n\
-_checkSpecies2:\n\
-    adds r1, r5, 0\n\
-    bl sub_80C03C8\n\
-    b _break\n\
-    .align 2, 0\n\
-_080C0388: .4byte gSaveBlock1 + 0x2738\n\
-_default:\n\
-    lsls r0, r6, 24\n\
-    lsrs r0, 24\n\
-    bl sub_80C03A8\n\
-_break:\n\
-    adds r0, r6, 0x1\n\
-    lsls r0, 16\n\
-    lsrs r6, r0, 16\n\
-    cmp r6, 0x17\n\
-    bhi _080C03A0\n\
-    b _080C01D8\n\
-_080C03A0:\n\
-    pop {r4-r6}\n\
-    pop {r0}\n\
-    bx r0\n\
-.syntax divided\n");
-}
-#endif
 
 void sub_80C03A8(u8 showidx)
 {

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -86,20 +86,12 @@ static bool8 CheckFeebas(void)
         x -= 7;
         y -= 7;
 
-#ifdef NONMATCHING
+        if (y >= gRoute119WaterTileData[3 * 0 + 0] && y <= gRoute119WaterTileData[3 * 0 + 1])
+            route119section = 0;
         if (y >= gRoute119WaterTileData[3 * 1 + 0] && y <= gRoute119WaterTileData[3 * 1 + 1])
             route119section = 1;
         if (y >= gRoute119WaterTileData[3 * 2 + 0] && y <= gRoute119WaterTileData[3 * 2 + 1])
             route119section = 2;
-#else
-        {
-            register const u16 *arr asm("r0");
-            if (y >= (arr = gRoute119WaterTileData)[3 * 1 + 0] && y <= arr[3 * 1 + 1])
-                route119section = 1;
-            if (y >= arr[3 * 2 + 0] && y <= arr[3 * 2 + 1])
-                route119section = 2;
-        }
-#endif
 
         if (Random() % 100 > 49) //50% chance of encountering Feebas
             return FALSE;


### PR DESCRIPTION
wild_encounter.c: port Feebas fix which was somehow in pokeemerald but not here.

battle/anim/unused_9.c: match sub_80CFE2C. When I came upon this function, the use of 8 and 9 specifically in array offset calculation reminded me of VS 2012 doing the same thing, but with negative numbers! So this guess on how to fix it became obvious and it worked. :)
You might want to check other places where the for variable could be used for offset calculation, that could be the key to fixing some more NONMATCHINGs.

field_effect_helpers.c: port MATCHING fixes from pokeemerald.

tv.c: match sub_80C01D4. Secondary temp u16.