### PR TITLE
Resolve GCC-10.1.0 compiler warnings

### DIFF
--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -23,7 +23,7 @@ struct UnknownStruct5
     u32 unk4;
     u32 unk8;
     u32 unkC;
-    u32 unk10;
+    int unk10;
 };
 
 struct UnknownStruct7
@@ -680,7 +680,7 @@ void sub_8043D84(u8 a, u8 b, u32 c, u32 d, u32 e)
     ewram17850[a].unk4 = c;
     ewram17850[a].unk8 = d;
     ewram17850[a].unkC = e;
-    ewram17850[a].unk10 = 0xFFFF8000;
+    ewram17850[a].unk10 = -0x8000;
 }
 
 void sub_8043DB0(u8 a)

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -2221,7 +2221,7 @@ static void sub_808DF88(u16 a, u8 b, u8 c, u16 d)
 
 static u8 sub_808DFE4(u16 num, u8 b, u8 c)
 {
-    u8 text[10];
+    u8 text[POKEMON_NAME_LENGTH + (MODERN ? 1 : 0)];
     u8 i;
 
     for (i = 0; i < 10; i++)
@@ -2232,11 +2232,11 @@ static u8 sub_808DFE4(u16 num, u8 b, u8 c)
     switch (num)
     {
     default:
-        for (i = 0; gSpeciesNames[num][i] != EOS && i < 10; i++)
+        for (i = 0; gSpeciesNames[num][i] != EOS && i < POKEMON_NAME_LENGTH; i++)
             text[i] = gSpeciesNames[num][i];
         break;
     case 0:
-        for (i = 0; i < 10; i++)
+        for (i = 0; i < POKEMON_NAME_LENGTH; i++)
             text[i] = CHAR_HYPHEN;
         break;
     }


### PR DESCRIPTION
battle_interface.c: Retyped UnknownStruct5->unk10 from u32 to int
pokedex.c: Widened the stack buffer in sub_808DFE4 from 10 bytes to 11; used the POKEMON_NAME_LENGTH macro here