### PR TITLE
Add German v1.1 target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,5 +68,8 @@ matrix:
         - make -j2 compare_ruby_de
         - make -j2 compare_sapphire_de
         - make -j2 compare_ruby_de_debug
+        - make -j2 compare_sapphire_de_debug
+        - make -j2 compare_ruby_de_rev1
+        - make -j2 compare_sapphire_de_rev1
 after_success:
   - .travis/calcrom/webhook.sh pokeruby

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ endif
 
 #### Main Rules ####
 
-ALL_BUILDS := ruby ruby_debug ruby_rev1 ruby_rev2 sapphire sapphire_debug sapphire_rev1 sapphire_rev2 ruby_de ruby_de_debug sapphire_de sapphire_de_debug
+ALL_BUILDS := ruby ruby_debug ruby_rev1 ruby_rev2 sapphire sapphire_debug sapphire_rev1 sapphire_rev2 ruby_de ruby_de_debug ruby_de_rev1 sapphire_de sapphire_de_debug sapphire_de_rev1
 MODERN_BUILDS := $(ALL_BUILDS:%=%_modern)
 
 # Available targets
@@ -226,8 +226,10 @@ sapphire_rev1:     ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_REVISION=1
 sapphire_rev2:     ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_REVISION=2
 ruby_de:           ; @$(MAKE) GAME_VERSION=RUBY GAME_LANGUAGE=GERMAN
 ruby_de_debug:     ; @$(MAKE) GAME_VERSION=RUBY GAME_LANGUAGE=GERMAN DEBUG=1
+ruby_de_rev1:      ; @$(MAKE) GAME_VERSION=RUBY GAME_LANGUAGE=GERMAN GAME_REVISION=1
 sapphire_de:       ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_LANGUAGE=GERMAN
 sapphire_de_debug: ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_LANGUAGE=GERMAN DEBUG=1
+sapphire_de_rev1:  ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_LANGUAGE=GERMAN GAME_REVISION=1
 
 modern:                   ; @$(MAKE) GAME_VERSION=RUBY MODERN=1
 ruby_modern:              ; @$(MAKE) GAME_VERSION=RUBY MODERN=1
@@ -240,8 +242,10 @@ sapphire_rev1_modern:     ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_REVISION=1 MODER
 sapphire_rev2_modern:     ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_REVISION=2 MODERN=1
 ruby_de_modern:           ; @$(MAKE) GAME_VERSION=RUBY GAME_LANGUAGE=GERMAN MODERN=1
 ruby_de_debug_modern:     ; @$(MAKE) GAME_VERSION=RUBY GAME_LANGUAGE=GERMAN DEBUG=1 MODERN=1
+ruby_de_rev1_modern:      ; @$(MAKE) GAME_VERSION=RUBY GAME_LANGUAGE=GERMAN GAME_REVISION=1 MODERN=1
 sapphire_de_modern:       ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_LANGUAGE=GERMAN MODERN=1
 sapphire_de_debug_modern: ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_LANGUAGE=GERMAN DEBUG=1 MODERN=1
+sapphire_de_rev1_modern:  ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_LANGUAGE=GERMAN GAME_REVISION=1 MODERN=1
 
 compare_ruby:              ; @$(MAKE) GAME_VERSION=RUBY COMPARE=1
 compare_ruby_debug:        ; @$(MAKE) GAME_VERSION=RUBY DEBUG=1 COMPARE=1
@@ -253,8 +257,10 @@ compare_sapphire_rev1:     ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_REVISION=1 COMP
 compare_sapphire_rev2:     ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_REVISION=2 COMPARE=1
 compare_ruby_de:           ; @$(MAKE) GAME_VERSION=RUBY GAME_LANGUAGE=GERMAN COMPARE=1
 compare_ruby_de_debug:     ; @$(MAKE) GAME_VERSION=RUBY GAME_LANGUAGE=GERMAN DEBUG=1 COMPARE=1
+compare_ruby_de_rev1:      ; @$(MAKE) GAME_VERSION=RUBY GAME_LANGUAGE=GERMAN GAME_REVISION=1 COMPARE=1
 compare_sapphire_de:       ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_LANGUAGE=GERMAN COMPARE=1
 compare_sapphire_de_debug: ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_LANGUAGE=GERMAN DEBUG=1 COMPARE=1
+compare_sapphire_de_rev1:  ; @$(MAKE) GAME_VERSION=SAPPHIRE GAME_LANGUAGE=GERMAN GAME_REVISION=1 COMPARE=1
 
 #### Graphics Rules ####
 

--- a/config.mk
+++ b/config.mk
@@ -27,6 +27,19 @@ else
 endif
 endif
 
+# Language
+ifeq ($(GAME_LANGUAGE), ENGLISH)
+  BUILD_NAME := $(BUILD_NAME)
+  GAME_CODE  := $(GAME_CODE)E
+else
+ifeq ($(GAME_LANGUAGE), GERMAN)
+  BUILD_NAME := $(BUILD_NAME)_de
+  GAME_CODE  := $(GAME_CODE)D
+else
+  $(error unknown language $(GAME_LANGUAGE))
+endif
+endif
+
 # Revision
 ifeq ($(GAME_REVISION), 0)
   BUILD_NAME := $(BUILD_NAME)
@@ -39,19 +52,6 @@ ifeq ($(GAME_REVISION), 2)
 else
   $(error unknown revision $(GAME_REVISION))
 endif
-endif
-endif
-
-# Language
-ifeq ($(GAME_LANGUAGE), ENGLISH)
-  BUILD_NAME := $(BUILD_NAME)
-  GAME_CODE  := $(GAME_CODE)E
-else
-ifeq ($(GAME_LANGUAGE), GERMAN)
-  BUILD_NAME := $(BUILD_NAME)_de
-  GAME_CODE  := $(GAME_CODE)D
-else
-  $(error unknown language $(GAME_LANGUAGE))
 endif
 endif
 

--- a/ruby_de_rev1.sha1
+++ b/ruby_de_rev1.sha1
@@ -1,0 +1,1 @@
+424740be1fc67a5ddb954794443646e6aeee2c1b  pokeruby_de_rev1.gba

--- a/sapphire_de_rev1.sha1
+++ b/sapphire_de_rev1.sha1
@@ -1,0 +1,1 @@
+7e6e034f9cdca6d2c4a270fdb50a94def5883d17  pokesapphire_de_rev1.gba

--- a/src/libs/agb_flash_mx.c
+++ b/src/libs/agb_flash_mx.c
@@ -26,7 +26,7 @@ const struct FlashSetupInfo MX29L010 =
                0  // appears to be unused
         },
         { 3, 1 }, // wait state setup data
-#if (GERMAN && SAPPHIRE && !DEBUG) // OK, why !DEBUG?
+#if (GERMAN && SAPPHIRE && REVISON == 0 && !DEBUG) // OK, why !DEBUG?
         { { 0xBF, 0xD4 } } // ID
 #else
         { { 0xC2, 0x09 } } // ID

--- a/src/libs/agb_flash_mx.c
+++ b/src/libs/agb_flash_mx.c
@@ -26,7 +26,7 @@ const struct FlashSetupInfo MX29L010 =
                0  // appears to be unused
         },
         { 3, 1 }, // wait state setup data
-#if (GERMAN && SAPPHIRE && REVISON == 0 && !DEBUG) // OK, why !DEBUG?
+#if (GERMAN && SAPPHIRE && (REVISION == 0) && !DEBUG) // OK, why !DEBUG?
         { { 0xBF, 0xD4 } } // ID
 #else
         { { 0xC2, 0x09 } } // ID


### PR DESCRIPTION
Only a simple Makefile edit was required to support this, as include/config.h already sets BUGFIX_BERRY for German rev1.

PR also adds German Sapphire debug to Travis tests.