### PR TITLE
docs: fix simple typo, occurr -> occur

### DIFF
--- a/src/scanline_effect.c
+++ b/src/scanline_effect.c
@@ -92,7 +92,7 @@ void ScanlineEffect_InitHBlankDmaTransfer(void)
     {
         DmaStop(0);
         // Set DMA to copy to dest register on each HBlank for the next frame.
-        // The HBlank DMA transfers do not occurr during VBlank, so the transfer
+        // The HBlank DMA transfers do not occur during VBlank, so the transfer
         // will begin on the HBlank after the first scanline
         DmaSet(0, gScanlineEffect.dmaSrcBuffers[gScanlineEffect.srcBuffer], gScanlineEffect.dmaDest, gScanlineEffect.dmaControl);
         // Manually set the reg for the first scanline


### PR DESCRIPTION
There is a small typo in src/scanline_effect.c.

Should read `occur` rather than `occurr`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md