### PR TITLE
Improve IDE Support

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -9,16 +9,17 @@
 #include "constants/global.h"
 
 // IDE support
-#if defined (__APPLE__) || defined (__CYGWIN__) || defined (__INTELLISENSE__)
-#define _(x) x
-#define __(x) x
-#define INCBIN(x) {0}
-#define INCBIN_U8 INCBIN
-#define INCBIN_U16 INCBIN
-#define INCBIN_U32 INCBIN
-#define INCBIN_S8 INCBIN
-#define INCBIN_S16 INCBIN
-#define INCBIN_S32 INCBIN
+#if defined(__APPLE__) || defined(__CYGWIN__) || defined(__INTELLISENSE__)
+// We define these when using certain IDEs to fool preproc
+#define _(x)        (x)
+#define __(x)       (x)
+#define INCBIN(...) {0}
+#define INCBIN_U8   INCBIN
+#define INCBIN_U16  INCBIN
+#define INCBIN_U32  INCBIN
+#define INCBIN_S8   INCBIN
+#define INCBIN_S16  INCBIN
+#define INCBIN_S32  INCBIN
 #endif // IDE support
 
 // For debug menu translations.


### PR DESCRIPTION
Small change to add `(__INTELLISENSE__)` to fix compatibility with VSCode.

## Description
`__INTELLISENSE__` is defined when using both Visual Studio and VSCode. It's mentioned here, specifically to be used for this sort of thing - https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160#microsoft-specific-predefined-macros

Since IntelliSense is the thing that causes the errors on both Visual Studio and VSCode, this should fix all of the `function call is not allowed in a constant expressionC/C++(59)` for both of them.


## **Discord contact info**
Jademalo#3486