### PR TITLE
Add *.latfont, *.hwjpnfont, and *.fwjpnfont to make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ syms: $(SYM)
 mostlyclean: tidy
 	find sound/direct_sound_samples \( -iname '*.bin' \) -exec rm {} +
 	$(RM) $(ALL_OBJECTS)
-	find . \( -iname '*.1bpp' -o -iname '*.4bpp' -o -iname '*.8bpp' -o -iname '*.gbapal' -o -iname '*.lz' -o -iname '*.rl' \) -exec rm {} +
+	find . \( -iname '*.1bpp' -o -iname '*.4bpp' -o -iname '*.8bpp' -o -iname '*.gbapal' -o -iname '*.lz' -o -iname '*.rl' -o -iname '*.latfont' -o -iname '*.hwjpnfont' -o -iname '*.fwjpnfont' \) -exec rm {} +
 	rm -f data/layouts/layouts.inc data/layouts/layouts_table.inc
 	rm -f data/maps/connections.inc data/maps/events.inc data/maps/groups.inc data/maps/headers.inc
 	find data/maps \( -iname 'connections.inc' -o -iname 'events.inc' -o -iname 'header.inc' \) -exec rm {} +


### PR DESCRIPTION
ExpoSeed noticed in pokeemerald that *.rl (RLE compressed) files were not being cleaned with the rest of the work files in `make clean`, which prompted me to find any similar issues in pokeruby, finding that *.latfont, *.hwjpnfont, and *.fwjpnfont files aren't being cleaned in pokeruby's `make clean`.
This PR aims to resolve this minor issue.
Companion PRs at https://github.com/pret/pokeemerald/pull/1225 and https://github.com/pret/pokefirered/pull/517