### PR TITLE
Correct KEY_INTR_ENABLE

### DIFF
--- a/include/gba/io_reg.h
+++ b/include/gba/io_reg.h
@@ -693,7 +693,7 @@
 #define R_BUTTON        0x0100
 #define L_BUTTON        0x0200
 #define KEYS_MASK       0x03FF
-#define KEY_INTR_ENABLE 0x0400
+#define KEY_INTR_ENABLE 0x4000
 #define KEY_OR_INTR     0x0000
 #define KEY_AND_INTR    0x8000
 #define DPAD_ANY        0x00F0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This changes the value of `KEY_INTR_ENABLE` to `0x4000`, which matches the value given in tonc, GBATEK, and other sources

## **Discord contact info**
whengryphonsfly