### PR TITLE
[LEAK-INFORMED] Add `blockBoxRS` field to `struct BoxPokemon`

### DIFF
--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -139,6 +139,7 @@ struct BoxPokemon
     /*0x13*/ u8 isBadEgg:1;
              u8 hasSpecies:1;
              u8 isEgg:1;
+             u8 blockBoxRS:1; // Unused, but Pokémon Box Ruby & Sapphire will refuse to deposit a Pokémon with this flag set
     /*0x14*/ u8 otName[OT_NAME_LENGTH];
     /*0x1B*/ u8 markings;
     /*0x1C*/ u16 checksum;


### PR DESCRIPTION
## Description
Documents an unused data field in the Pokémon data structure.  None of the GBA games read or write to it, and to my knowledge, no event distributions utilized it.  I have not observed any behavior related to it in Colosseum, XD: Gale of Darkness, Diamond, Pearl, Platinum, HeartGold, or SoulSilver, but Box: Ruby & Sapphire will display "There is a Pokémon that can't be transferred" when trying to deposit a Pokémon that has the flag set to `TRUE`.

## **Discord contact info**
`@citrusbolt`