### PR TITLE
VictoryRoad script+dialogue naming update.

### DIFF
--- a/data-de/maps/VictoryRoad_1F/text.inc
+++ b/data-de/maps/VictoryRoad_1F/text.inc
@@ -1,4 +1,4 @@
-VictoryRoad_1F_Text_19782B:: @ 819782B
+VictoryRoad_1F_Text_WallyNotGoingToLoseAnymore:: @ 819782B
 	.string "HEIKO: Hallo, {PLAYER}!\p"
 	.string "Du bist bestimmt überrascht, mich hier\n"
 	.string "zu treffen!\p"
@@ -11,65 +11,65 @@ VictoryRoad_1F_Text_19782B:: @ 819782B
 	.string "die mir Mut und Kraft gegeben haben!\p"
 	.string "Okay... Jetzt komme ich!$"
 
-VictoryRoad_1F_Text_197943:: @ 8197943
+VictoryRoad_1F_Text_WallyEntranceDefeat:: @ 8197943
 	.string "Wow!\n"
 	.string "{PLAYER}, du wirst immer stärker!$"
 
-VictoryRoad_1F_Text_197967:: @ 8197967
+VictoryRoad_1F_Text_WallyPostEntranceBattle:: @ 8197967
 	.string "HEIKO: Ich konnte dich heute nicht be-\n"
 	.string "siegen, aber eines Tages werde ich es\l"
 	.string "mit dir aufnehmen!$"
 
-VictoryRoad_1F_Text_1979BA:: @ 81979BA
+VictoryRoad_1F_Text_WallyIntro:: @ 81979BA
 	.string "HEIKO: Hallo, {PLAYER}!\p"
 	.string "Ich bin viel stärker geworden! Das\n"
 	.string "möchte ich dir zeigen, {PLAYER}!\p"
 	.string "Okay... Jetzt komme ich!$"
 
-VictoryRoad_1F_Text_197A23:: @ 8197A23
+VictoryRoad_1F_Text_WallyDefeat:: @ 8197A23
 	.string "Wow!\n"
 	.string "{PLAYER}, du bist immer noch zu stark!$"
 
-VictoryRoad_1F_Text_197A47:: @ 8197A47
+VictoryRoad_1F_Text_WallyPostBattle:: @ 8197A47
 	.string "HEIKO: Ich konnte dich wieder nicht\n"
 	.string "besiegen... Aber eines Tages, {PLAYER},\l"
 	.string "eines Tages...\p"
 	.string "Da werde ich sogar die POKéMON LIGA\n"
 	.string "herausfordern!$"
 
-VictoryRoad_1F_Text_197AD1:: @ 8197AD1
+VictoryRoad_1F_Text_EdgarIntro:: @ 8197AD1
 	.string "Ich habe es innerhalb kürzester Zeit\n"
 	.string "bis hierher geschafft, aber das letzte\l"
 	.string "Stück zieht sich wie Kaugummi...$"
 
-VictoryRoad_1F_Text_197B1A:: @ 8197B1A
+VictoryRoad_1F_Text_EdgarDefeat:: @ 8197B1A
 	.string "Hier enden meine Träume...$"
 
-VictoryRoad_1F_Text_197B36:: @ 8197B36
+VictoryRoad_1F_Text_EdgarPostBattle:: @ 8197B36
 	.string "Du bist weit gekommen. Lasse nicht nach\n"
 	.string "und versuche, der CHAMP zu werden!\l"
 	.string "Wenn einer das kann, dann du!$"
 
-VictoryRoad_1F_Text_197B99:: @ 8197B99
+VictoryRoad_1F_Text_AlbertIntro:: @ 8197B99
 	.string "Ich bin nicht hierher gekommen, um zu\n"
 	.string "verlieren. Diese Option existiert nicht!$"
 
-VictoryRoad_1F_Text_197BE1:: @ 8197BE1
+VictoryRoad_1F_Text_AlbertDefeat:: @ 8197BE1
 	.string "Unmöglich...\n"
 	.string "Ich habe verloren???$"
 
-VictoryRoad_1F_Text_197BF7:: @ 8197BF7
+VictoryRoad_1F_Text_AlbertPostBattle:: @ 8197BF7
 	.string "Ich habe hier verloren...\p"
 	.string "Das heißt, mir fehlt noch eine Menge,\n"
 	.string "um CHAMP werden zu können.$"
 
-VictoryRoad_1F_Text_197C45:: @ 8197C45
+VictoryRoad_1F_Text_HopeIntro:: @ 8197C45
 	.string "Diese unendliche, raue Straße wird\n"
 	.string "ihrem Namen - SIEG - gerecht.$"
 
-VictoryRoad_1F_Text_197C8D:: @ 8197C8D
+VictoryRoad_1F_Text_HopeDefeat:: @ 8197C8D
 	.string "Dein Kampfstil ist fantastisch...$"
 
-VictoryRoad_1F_Text_197CAF:: @ 8197CAF
+VictoryRoad_1F_Text_HopePostBattle:: @ 8197CAF
 	.string "Du hast wirklich das Potential, der\n"
 	.string "CHAMP zu werden.$"

--- a/data-de/maps/VictoryRoad_B1F/text.inc
+++ b/data-de/maps/VictoryRoad_B1F/text.inc
@@ -1,37 +1,37 @@
-VictoryRoad_B1F_Text_197CE9:: @ 8197CE9
+VictoryRoad_B1F_Text_SamuelIntro:: @ 8197CE9
 	.string "Der Gedanke, dass ich der POKéMON LIGA\n"
 	.string "immer näher komme...\p"
 	.string "Ich bekomme Lampenfieber...$"
 
-VictoryRoad_B1F_Text_197D42:: @ 8197D42
+VictoryRoad_B1F_Text_SamuelDefeat:: @ 8197D42
 	.string "Ich konnte gar nichts machen...$"
 
-VictoryRoad_B1F_Text_197D5B:: @ 8197D5B
+VictoryRoad_B1F_Text_SamuelPostBattle:: @ 8197D5B
 	.string "Die POKéMON LIGA rückt in weite Ferne...\n"
 	.string "Was für eine Enttäuschung...$"
 
-VictoryRoad_B1F_Text_197D98:: @ 8197D98
+VictoryRoad_B1F_Text_ShannonIntro:: @ 8197D98
 	.string "Um dich siegreich durch die POKéMON\n"
 	.string "LIGA zu kämpfen, brauchst du das\l"
 	.string "Vertrauen deiner POKéMON.$"
 
-VictoryRoad_B1F_Text_197DE8:: @ 8197DE8
+VictoryRoad_B1F_Text_ShannonDefeat:: @ 8197DE8
 	.string "Eure Beziehung ist auf solidem\n"
 	.string "Vertrauen aufgebaut.$"
 
-VictoryRoad_B1F_Text_197E13:: @ 8197E13
+VictoryRoad_B1F_Text_ShannonPostBattle:: @ 8197E13
 	.string "Das Vertrauen zwischen POKéMON und\n"
 	.string "TRAINER wächst beständig, da sie immer\l"
 	.string "zusammen sind.$"
 
-VictoryRoad_B1F_Text_197E5D:: @ 8197E5D
+VictoryRoad_B1F_Text_MichelleIntro:: @ 8197E5D
 	.string "Das ist nicht das Ziel. Nur eine\n"
 	.string "Zwischenstation auf dem Weg zur\l"
 	.string "POKéMON LIGA.$"
 
-VictoryRoad_B1F_Text_197EA6:: @ 8197EA6
+VictoryRoad_B1F_Text_MichelleDefeat:: @ 8197EA6
 	.string "Das ist der Weg!$"
 
-VictoryRoad_B1F_Text_197EB6:: @ 8197EB6
+VictoryRoad_B1F_Text_MichellePostBattle:: @ 8197EB6
 	.string "Du wirst dich sehr gut schlagen, das ist\n"
 	.string "sicher. Deine POKéMON lieben dich!$"

--- a/data-de/maps/VictoryRoad_B2F/text.inc
+++ b/data-de/maps/VictoryRoad_B2F/text.inc
@@ -1,50 +1,50 @@
-VictoryRoad_B2F_Text_197EF2:: @ 8197EF2
+VictoryRoad_B2F_Text_VitoIntro:: @ 8197EF2
 	.string "Ich habe mit meiner Familie trainiert,\n"
 	.string "mit jedem einzelnen Mitglied!\l"
 	.string "Ich verliere gegen niemanden!$"
 
-VictoryRoad_B2F_Text_197F46:: @ 8197F46
+VictoryRoad_B2F_Text_VitoDefeat:: @ 8197F46
 	.string "Besser als meine Familie?\n"
 	.string "Ist das möglich?$"
 
-VictoryRoad_B2F_Text_197F71:: @ 8197F71
+VictoryRoad_B2F_Text_VitoPostBattle:: @ 8197F71
 	.string "Ich war besser als jeder andere aus\n"
 	.string "meiner Familie. Ich habe nie verloren!\p"
 	.string "Ich habe mein Selbstvertrauen ver-\n"
 	.string "loren. Ich gehe nach Hause...$"
 
-VictoryRoad_B2F_Text_197FE5:: @ 8197FE5
+VictoryRoad_B2F_Text_OwenIntro:: @ 8197FE5
 	.string "Ich habe gehört, dass sich hier ein sehr\n"
 	.string "starkes Kind herumtreibt. Bist du das?$"
 
-VictoryRoad_B2F_Text_19802B:: @ 819802B
+VictoryRoad_B2F_Text_OwenDefeat:: @ 819802B
 	.string "Diese kleine Kröte ist echt stark!$"
 
-VictoryRoad_B2F_Text_198047:: @ 8198047
+VictoryRoad_B2F_Text_OwenPostBattle:: @ 8198047
 	.string "Das Gerücht sagt, das Kind käme aus\n"
 	.string "BLÜTENBURG CITY.$"
 
-VictoryRoad_B2F_Text_198089:: @ 8198089
+VictoryRoad_B2F_Text_CarolineIntro:: @ 8198089
 	.string "Du musst doch langsam mal müde werden.$"
 
-VictoryRoad_B2F_Text_1980AD:: @ 81980AD
+VictoryRoad_B2F_Text_CarolineDefeat:: @ 81980AD
 	.string "Keine Anzeichen von Müdigkeit...$"
 
-VictoryRoad_B2F_Text_1980C8:: @ 81980C8
+VictoryRoad_B2F_Text_CarolinePostBattle:: @ 81980C8
 	.string "Die SIEGESSTRASSE und die POKéMON\n"
 	.string "LIGA sind große und langwierige Heraus-\l"
 	.string "forderungen. Werde bloß nicht müde!!!$"
 
-VictoryRoad_B2F_Text_198121:: @ 8198121
+VictoryRoad_B2F_Text_JulieIntro:: @ 8198121
 	.string "Du solltest nicht selbstzufrieden\n"
 	.string "werden, nur weil du viele ORDEN der\l"
 	.string "ARENEN besitzt.\p"
 	.string "Es wird immer jemanden geben, der\n"
 	.string "besser ist als du!$"
 
-VictoryRoad_B2F_Text_1981A3:: @ 81981A3
+VictoryRoad_B2F_Text_JulieDefeat:: @ 81981A3
 	.string "Du bist besser als ich!$"
 
-VictoryRoad_B2F_Text_1981BA:: @ 81981BA
+VictoryRoad_B2F_Text_JuliePostBattle:: @ 81981BA
 	.string "Schau dir deine ORDEN an - erinnere dich\n"
 	.string "an die TRAINER, die du getroffen hast.$"

--- a/data/maps/VictoryRoad_1F/map.json
+++ b/data/maps/VictoryRoad_1F/map.json
@@ -21,7 +21,7 @@
       "movement_range_y": 0,
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
-      "script": "VictoryRoad_1F_EventScript_15DF6F",
+      "script": "VictoryRoad_1F_EventScript_Edgar",
       "flag": "0"
     },
     {
@@ -34,7 +34,7 @@
       "movement_range_y": 0,
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
-      "script": "VictoryRoad_1F_EventScript_15DF9D",
+      "script": "VictoryRoad_1F_EventScript_Hope",
       "flag": "0"
     },
     {
@@ -47,7 +47,7 @@
       "movement_range_y": 0,
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
-      "script": "VictoryRoad_1F_EventScript_15DF86",
+      "script": "VictoryRoad_1F_EventScript_Albert",
       "flag": "0"
     },
     {
@@ -60,7 +60,7 @@
       "movement_range_y": 1,
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
-      "script": "VictoryRoad_1F_EventScript_15DF28",
+      "script": "VictoryRoad_1F_EventScript_WallyRematchPostBattle",
       "flag": "FLAG_HIDE_WALLY_BATTLE_VICTORY_ROAD"
     },
     {
@@ -99,7 +99,7 @@
       "movement_range_y": 1,
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
-      "script": "VictoryRoad_1F_EventScript_15DF31",
+      "script": "VictoryRoad_1F_EventScript_Wally",
       "flag": "FLAG_HIDE_WALLY_DEFEATED_VICTORY_ROAD"
     }
   ],
@@ -148,7 +148,7 @@
       "elevation": 3,
       "var": "VAR_VICTORY_ROAD_1F_STATE",
       "var_value": "0",
-      "script": "VictoryRoad_1F_EventScript_15DE97"
+      "script": "VictoryRoad_1F_EventScript_WallyTrigger0"
     },
     {
       "type": "trigger",
@@ -157,7 +157,7 @@
       "elevation": 3,
       "var": "VAR_VICTORY_ROAD_1F_STATE",
       "var_value": "0",
-      "script": "VictoryRoad_1F_EventScript_15DEAB"
+      "script": "VictoryRoad_1F_EventScript_WallyTrigger1"
     },
     {
       "type": "trigger",
@@ -166,7 +166,7 @@
       "elevation": 3,
       "var": "VAR_VICTORY_ROAD_1F_STATE",
       "var_value": "0",
-      "script": "VictoryRoad_1F_EventScript_15DEBF"
+      "script": "VictoryRoad_1F_EventScript_WallyTrigger2"
     }
   ],
   "bg_events": [

--- a/data/maps/VictoryRoad_1F/scripts.inc
+++ b/data/maps/VictoryRoad_1F/scripts.inc
@@ -1,45 +1,45 @@
 VictoryRoad_1F_MapScripts:: @ 815DE83
-	map_script MAP_SCRIPT_ON_TRANSITION, VictoryRoad_1F_MapScript1_15DE89
+	map_script MAP_SCRIPT_ON_TRANSITION, VictoryRoad_1F_OnTransition
 	.byte 0
 
-VictoryRoad_1F_MapScript1_15DE89:: @ 815DE89
-	call_if_set FLAG_DEFEATED_WALLY_VICTORY_ROAD, VictoryRoad_1F_EventScript_15DE93
+VictoryRoad_1F_OnTransition:: @ 815DE89
+	call_if_set FLAG_DEFEATED_WALLY_VICTORY_ROAD, VictoryRoad_1F_EventScript_HideWally
 	end
 
-VictoryRoad_1F_EventScript_15DE93:: @ 815DE93
+VictoryRoad_1F_EventScript_HideWally:: @ 815DE93
 	setflag FLAG_HIDE_WALLY_BATTLE_VICTORY_ROAD
 	return
 
-VictoryRoad_1F_EventScript_15DE97:: @ 815DE97
+VictoryRoad_1F_EventScript_WallyTrigger0:: @ 815DE97
 	lockall
 	addobject 4
-	applymovement 4, VictoryRoad_1F_Movement_15DF07
+	applymovement 4, VictoryRoad_1F_Movement_WallyApproachPlayer0
 	waitmovement 0
-	goto VictoryRoad_1F_EventScript_15DED3
+	goto VictoryRoad_1F_EventScript_WallyApproachPlayer
 	end
 
-VictoryRoad_1F_EventScript_15DEAB:: @ 815DEAB
+VictoryRoad_1F_EventScript_WallyTrigger1:: @ 815DEAB
 	lockall
 	addobject 4
-	applymovement 4, VictoryRoad_1F_Movement_15DF13
+	applymovement 4, VictoryRoad_1F_Movement_WallyApproachPlayer1
 	waitmovement 0
-	goto VictoryRoad_1F_EventScript_15DED3
+	goto VictoryRoad_1F_EventScript_WallyApproachPlayer
 	end
 
-VictoryRoad_1F_EventScript_15DEBF:: @ 815DEBF
+VictoryRoad_1F_EventScript_WallyTrigger2:: @ 815DEBF
 	lockall
 	addobject 4
-	applymovement 4, VictoryRoad_1F_Movement_15DF1E
+	applymovement 4, VictoryRoad_1F_Movement_WallyApproachPlayer2
 	waitmovement 0
-	goto VictoryRoad_1F_EventScript_15DED3
+	goto VictoryRoad_1F_EventScript_WallyApproachPlayer
 	end
 
-VictoryRoad_1F_EventScript_15DED3:: @ 815DED3
+VictoryRoad_1F_EventScript_WallyApproachPlayer:: @ 815DED3
 	applymovement OBJ_EVENT_ID_PLAYER, Common_Movement_WalkInPlaceFastestLeft
 	waitmovement 0
-	msgbox VictoryRoad_1F_Text_19782B, MSGBOX_DEFAULT
-	trainerbattle_no_intro TRAINER_WALLY_1, VictoryRoad_1F_Text_197943
-	msgbox VictoryRoad_1F_Text_197967, MSGBOX_DEFAULT
+	msgbox VictoryRoad_1F_Text_WallyNotGoingToLoseAnymore, MSGBOX_DEFAULT
+	trainerbattle_no_intro TRAINER_WALLY_1, VictoryRoad_1F_Text_WallyEntranceDefeat
+	msgbox VictoryRoad_1F_Text_WallyPostEntranceBattle, MSGBOX_DEFAULT
 	clearflag FLAG_HIDE_WALLY_BATTLE_VICTORY_ROAD
 	moveobjectoffscreen 4
 	setflag FLAG_DEFEATED_WALLY_VICTORY_ROAD
@@ -47,7 +47,7 @@ VictoryRoad_1F_EventScript_15DED3:: @ 815DED3
 	releaseall
 	end
 
-VictoryRoad_1F_Movement_15DF07:: @ 815DF07
+VictoryRoad_1F_Movement_WallyApproachPlayer0:: @ 815DF07
 	walk_up
 	walk_up
 	walk_up
@@ -61,7 +61,7 @@ VictoryRoad_1F_Movement_15DF07:: @ 815DF07
 	walk_right
 	step_end
 
-VictoryRoad_1F_Movement_15DF13:: @ 815DF13
+VictoryRoad_1F_Movement_WallyApproachPlayer1:: @ 815DF13
 	walk_up
 	walk_up
 	walk_up
@@ -74,7 +74,7 @@ VictoryRoad_1F_Movement_15DF13:: @ 815DF13
 	walk_right
 	step_end
 
-VictoryRoad_1F_Movement_15DF1E:: @ 815DF1E
+VictoryRoad_1F_Movement_WallyApproachPlayer2:: @ 815DF1E
 	walk_up
 	walk_up
 	walk_up
@@ -86,34 +86,34 @@ VictoryRoad_1F_Movement_15DF1E:: @ 815DF1E
 	walk_right
 	step_end
 
-VictoryRoad_1F_EventScript_15DF28:: @ 815DF28
-	msgbox VictoryRoad_1F_Text_197967, MSGBOX_NPC
+VictoryRoad_1F_EventScript_WallyRematchPostBattle:: @ 815DF28
+	msgbox VictoryRoad_1F_Text_WallyPostEntranceBattle, MSGBOX_NPC
 	end
 
-VictoryRoad_1F_EventScript_15DF31:: @ 815DF31
-	trainerbattle_single TRAINER_WALLY_3, VictoryRoad_1F_Text_1979BA, VictoryRoad_1F_Text_197A23
+VictoryRoad_1F_EventScript_Wally:: @ 815DF31
+	trainerbattle_single TRAINER_WALLY_3, VictoryRoad_1F_Text_WallyIntro, VictoryRoad_1F_Text_WallyDefeat
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
-	goto_if_eq VictoryRoad_1F_EventScript_15DF58
-	msgbox VictoryRoad_1F_Text_197A47, MSGBOX_AUTOCLOSE
+	goto_if_eq VictoryRoad_1F_EventScript_WallyRematch
+	msgbox VictoryRoad_1F_Text_WallyPostBattle, MSGBOX_AUTOCLOSE
 	end
 
-VictoryRoad_1F_EventScript_15DF58:: @ 815DF58
-	trainerbattle_rematch TRAINER_WALLY_3, VictoryRoad_1F_Text_1979BA, VictoryRoad_1F_Text_197A23
-	msgbox VictoryRoad_1F_Text_197A47, MSGBOX_AUTOCLOSE
+VictoryRoad_1F_EventScript_WallyRematch:: @ 815DF58
+	trainerbattle_rematch TRAINER_WALLY_3, VictoryRoad_1F_Text_WallyIntro, VictoryRoad_1F_Text_WallyDefeat
+	msgbox VictoryRoad_1F_Text_WallyPostBattle, MSGBOX_AUTOCLOSE
 	end
 
-VictoryRoad_1F_EventScript_15DF6F:: @ 815DF6F
-	trainerbattle_single TRAINER_EDGAR, VictoryRoad_1F_Text_197AD1, VictoryRoad_1F_Text_197B1A
-	msgbox VictoryRoad_1F_Text_197B36, MSGBOX_AUTOCLOSE
+VictoryRoad_1F_EventScript_Edgar:: @ 815DF6F
+	trainerbattle_single TRAINER_EDGAR, VictoryRoad_1F_Text_EdgarIntro, VictoryRoad_1F_Text_EdgarDefeat
+	msgbox VictoryRoad_1F_Text_EdgarPostBattle, MSGBOX_AUTOCLOSE
 	end
 
-VictoryRoad_1F_EventScript_15DF86:: @ 815DF86
-	trainerbattle_single TRAINER_ALBERT, VictoryRoad_1F_Text_197B99, VictoryRoad_1F_Text_197BE1
-	msgbox VictoryRoad_1F_Text_197BF7, MSGBOX_AUTOCLOSE
+VictoryRoad_1F_EventScript_Albert:: @ 815DF86
+	trainerbattle_single TRAINER_ALBERT, VictoryRoad_1F_Text_AlbertIntro, VictoryRoad_1F_Text_AlbertDefeat
+	msgbox VictoryRoad_1F_Text_AlbertPostBattle, MSGBOX_AUTOCLOSE
 	end
 
-VictoryRoad_1F_EventScript_15DF9D:: @ 815DF9D
-	trainerbattle_single TRAINER_HOPE, VictoryRoad_1F_Text_197C45, VictoryRoad_1F_Text_197C8D
-	msgbox VictoryRoad_1F_Text_197CAF, MSGBOX_AUTOCLOSE
+VictoryRoad_1F_EventScript_Hope:: @ 815DF9D
+	trainerbattle_single TRAINER_HOPE, VictoryRoad_1F_Text_HopeIntro, VictoryRoad_1F_Text_HopeDefeat
+	msgbox VictoryRoad_1F_Text_HopePostBattle, MSGBOX_AUTOCLOSE
 	end

--- a/data/maps/VictoryRoad_1F/text.inc
+++ b/data/maps/VictoryRoad_1F/text.inc
@@ -1,4 +1,4 @@
-VictoryRoad_1F_Text_19782B:: @ 819782B
+VictoryRoad_1F_Text_WallyNotGoingToLoseAnymore:: @ 819782B
 	.string "WALLY: Hi! {PLAYER}!\p"
 	.string "I bet you're surprised to see me here!\p"
 	.string "I made it all the way here, and it's\n"
@@ -10,63 +10,63 @@ VictoryRoad_1F_Text_19782B:: @ 819782B
 	.string "gave me courage and strength!\p"
 	.string "Okay... Here I come!$"
 
-VictoryRoad_1F_Text_197943:: @ 8197943
+VictoryRoad_1F_Text_WallyEntranceDefeat:: @ 8197943
 	.string "Wow!\n"
 	.string "{PLAYER}, you are strong, after all!$"
 
-VictoryRoad_1F_Text_197967:: @ 8197967
+VictoryRoad_1F_Text_WallyPostEntranceBattle:: @ 8197967
 	.string "WALLY: I couldn't beat you today,\n"
 	.string "{PLAYER}, but one of these days, I'll\l"
 	.string "catch up to you!$"
 
-VictoryRoad_1F_Text_1979BA:: @ 81979BA
+VictoryRoad_1F_Text_WallyIntro:: @ 81979BA
 	.string "WALLY: Hi! {PLAYER}!\p"
 	.string "I've gotten stronger since that last\n"
 	.string "time! I wanted to show you, {PLAYER}!\p"
 	.string "Okay... Here I come!$"
 
-VictoryRoad_1F_Text_197A23:: @ 8197A23
+VictoryRoad_1F_Text_WallyDefeat:: @ 8197A23
 	.string "Wow!\n"
 	.string "{PLAYER}, you are strong, after all!$"
 
-VictoryRoad_1F_Text_197A47:: @ 8197A47
+VictoryRoad_1F_Text_WallyPostBattle:: @ 8197A47
 	.string "WALLY: I couldn't beat you this time,\n"
 	.string "too... But one of these days, {PLAYER},\l"
 	.string "I'm going to catch up to you...\p"
 	.string "And challenge the POKéMON LEAGUE!$"
 
-VictoryRoad_1F_Text_197AD1:: @ 8197AD1
+VictoryRoad_1F_Text_EdgarIntro:: @ 8197AD1
 	.string "I've made it this far a couple times,\n"
 	.string "but the last stretch is so long...$"
 
-VictoryRoad_1F_Text_197B1A:: @ 8197B1A
+VictoryRoad_1F_Text_EdgarDefeat:: @ 8197B1A
 	.string "My dream ends here again...$"
 
-VictoryRoad_1F_Text_197B36:: @ 8197B36
+VictoryRoad_1F_Text_EdgarPostBattle:: @ 8197B36
 	.string "You've made it this far. Keep the\n"
 	.string "momentum going and become the\l"
 	.string "CHAMPION! If anyone can, it's you!$"
 
-VictoryRoad_1F_Text_197B99:: @ 8197B99
+VictoryRoad_1F_Text_AlbertIntro:: @ 8197B99
 	.string "I didn't come all this way to lose now.\n"
 	.string "That possibility doesn't exist!$"
 
-VictoryRoad_1F_Text_197BE1:: @ 8197BE1
+VictoryRoad_1F_Text_AlbertDefeat:: @ 8197BE1
 	.string "Impossible...\n"
 	.string "I lost?$"
 
-VictoryRoad_1F_Text_197BF7:: @ 8197BF7
+VictoryRoad_1F_Text_AlbertPostBattle:: @ 8197BF7
 	.string "I lost here...\p"
 	.string "That means I lack the qualifications\n"
 	.string "to become the CHAMPION...$"
 
-VictoryRoad_1F_Text_197C45:: @ 8197C45
+VictoryRoad_1F_Text_HopeIntro:: @ 8197C45
 	.string "This seemingly infinite and harsh road\n"
 	.string "lives up to its name of VICTORY.$"
 
-VictoryRoad_1F_Text_197C8D:: @ 8197C8D
+VictoryRoad_1F_Text_HopeDefeat:: @ 8197C8D
 	.string "Your battle style is fantastic...$"
 
-VictoryRoad_1F_Text_197CAF:: @ 8197CAF
+VictoryRoad_1F_Text_HopePostBattle:: @ 8197CAF
 	.string "You seem to have the potential for\n"
 	.string "becoming the CHAMPION.$"

--- a/data/maps/VictoryRoad_B1F/map.json
+++ b/data/maps/VictoryRoad_B1F/map.json
@@ -190,7 +190,7 @@
       "movement_range_y": 0,
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "3",
-      "script": "VictoryRoad_B1F_EventScript_15DFB5",
+      "script": "VictoryRoad_B1F_EventScript_Samuel",
       "flag": "0"
     },
     {
@@ -203,7 +203,7 @@
       "movement_range_y": 0,
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
-      "script": "VictoryRoad_B1F_EventScript_15DFCC",
+      "script": "VictoryRoad_B1F_EventScript_Shannon",
       "flag": "0"
     },
     {
@@ -216,7 +216,7 @@
       "movement_range_y": 0,
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
-      "script": "VictoryRoad_B1F_EventScript_15DFE3",
+      "script": "VictoryRoad_B1F_EventScript_Michelle",
       "flag": "0"
     },
     {

--- a/data/maps/VictoryRoad_B1F/scripts.inc
+++ b/data/maps/VictoryRoad_B1F/scripts.inc
@@ -1,17 +1,17 @@
 VictoryRoad_B1F_MapScripts:: @ 815DFB4
 	.byte 0
 
-VictoryRoad_B1F_EventScript_15DFB5:: @ 815DFB5
-	trainerbattle_single TRAINER_SAMUEL, VictoryRoad_B1F_Text_197CE9, VictoryRoad_B1F_Text_197D42
-	msgbox VictoryRoad_B1F_Text_197D5B, MSGBOX_AUTOCLOSE
+VictoryRoad_B1F_EventScript_Samuel:: @ 815DFB5
+	trainerbattle_single TRAINER_SAMUEL, VictoryRoad_B1F_Text_SamuelIntro, VictoryRoad_B1F_Text_SamuelDefeat
+	msgbox VictoryRoad_B1F_Text_SamuelPostBattle, MSGBOX_AUTOCLOSE
 	end
 
-VictoryRoad_B1F_EventScript_15DFCC:: @ 815DFCC
-	trainerbattle_single TRAINER_SHANNON, VictoryRoad_B1F_Text_197D98, VictoryRoad_B1F_Text_197DE8
-	msgbox VictoryRoad_B1F_Text_197E13, MSGBOX_AUTOCLOSE
+VictoryRoad_B1F_EventScript_Shannon:: @ 815DFCC
+	trainerbattle_single TRAINER_SHANNON, VictoryRoad_B1F_Text_ShannonIntro, VictoryRoad_B1F_Text_ShannonDefeat
+	msgbox VictoryRoad_B1F_Text_ShannonPostBattle, MSGBOX_AUTOCLOSE
 	end
 
-VictoryRoad_B1F_EventScript_15DFE3:: @ 815DFE3
-	trainerbattle_single TRAINER_MICHELLE, VictoryRoad_B1F_Text_197E5D, VictoryRoad_B1F_Text_197EA6
-	msgbox VictoryRoad_B1F_Text_197EB6, MSGBOX_AUTOCLOSE
+VictoryRoad_B1F_EventScript_Michelle:: @ 815DFE3
+	trainerbattle_single TRAINER_MICHELLE, VictoryRoad_B1F_Text_MichelleIntro, VictoryRoad_B1F_Text_MichelleDefeat
+	msgbox VictoryRoad_B1F_Text_MichellePostBattle, MSGBOX_AUTOCLOSE
 	end

--- a/data/maps/VictoryRoad_B1F/text.inc
+++ b/data/maps/VictoryRoad_B1F/text.inc
@@ -1,35 +1,35 @@
-VictoryRoad_B1F_Text_197CE9:: @ 8197CE9
+VictoryRoad_B1F_Text_SamuelIntro:: @ 8197CE9
 	.string "The thought that I'm getting closer to\n"
 	.string "the POKéMON LEAGUE...\p"
 	.string "I'm getting stage fright...$"
 
-VictoryRoad_B1F_Text_197D42:: @ 8197D42
+VictoryRoad_B1F_Text_SamuelDefeat:: @ 8197D42
 	.string "I couldn't do a thing...$"
 
-VictoryRoad_B1F_Text_197D5B:: @ 8197D5B
+VictoryRoad_B1F_Text_SamuelPostBattle:: @ 8197D5B
 	.string "The POKéMON LEAGUE became distant\n"
 	.string "again... What a letdown...$"
 
-VictoryRoad_B1F_Text_197D98:: @ 8197D98
+VictoryRoad_B1F_Text_ShannonIntro:: @ 8197D98
 	.string "To win your way through the POKéMON\n"
 	.string "LEAGUE, you need the trust of your\l"
 	.string "POKéMON.$"
 
-VictoryRoad_B1F_Text_197DE8:: @ 8197DE8
+VictoryRoad_B1F_Text_ShannonDefeat:: @ 8197DE8
 	.string "Your relationship is based on\n"
 	.string "solid trust.$"
 
-VictoryRoad_B1F_Text_197E13:: @ 8197E13
+VictoryRoad_B1F_Text_ShannonPostBattle:: @ 8197E13
 	.string "By being together all the time, trust\n"
 	.string "grows between POKéMON and TRAINERS.$"
 
-VictoryRoad_B1F_Text_197E5D:: @ 8197E5D
+VictoryRoad_B1F_Text_MichelleIntro:: @ 8197E5D
 	.string "This isn't the goal. It's only a place\n"
 	.string "on the way to the POKéMON LEAGUE.$"
 
-VictoryRoad_B1F_Text_197EA6:: @ 8197EA6
+VictoryRoad_B1F_Text_MichelleDefeat:: @ 8197EA6
 	.string "That's the way!$"
 
-VictoryRoad_B1F_Text_197EB6:: @ 8197EB6
+VictoryRoad_B1F_Text_MichellePostBattle:: @ 8197EB6
 	.string "You'll do fine, for sure!\n"
 	.string "Your POKéMON are all eager to go!$"

--- a/data/maps/VictoryRoad_B2F/map.json
+++ b/data/maps/VictoryRoad_B2F/map.json
@@ -21,7 +21,7 @@
       "movement_range_y": 1,
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
-      "script": "VictoryRoad_B2F_EventScript_15DFFB",
+      "script": "VictoryRoad_B2F_EventScript_Vito",
       "flag": "0"
     },
     {
@@ -34,7 +34,7 @@
       "movement_range_y": 1,
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "4",
-      "script": "VictoryRoad_B2F_EventScript_15E012",
+      "script": "VictoryRoad_B2F_EventScript_Owen",
       "flag": "0"
     },
     {
@@ -47,7 +47,7 @@
       "movement_range_y": 1,
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
-      "script": "VictoryRoad_B2F_EventScript_15E029",
+      "script": "VictoryRoad_B2F_EventScript_Caroline",
       "flag": "0"
     },
     {
@@ -60,7 +60,7 @@
       "movement_range_y": 1,
       "trainer_type": "TRAINER_TYPE_NORMAL",
       "trainer_sight_or_berry_tree_id": "2",
-      "script": "VictoryRoad_B2F_EventScript_15E040",
+      "script": "VictoryRoad_B2F_EventScript_Julie",
       "flag": "0"
     },
     {

--- a/data/maps/VictoryRoad_B2F/scripts.inc
+++ b/data/maps/VictoryRoad_B2F/scripts.inc
@@ -1,22 +1,22 @@
 VictoryRoad_B2F_MapScripts:: @ 815DFFA
 	.byte 0
 
-VictoryRoad_B2F_EventScript_15DFFB:: @ 815DFFB
-	trainerbattle_single TRAINER_VITO, VictoryRoad_B2F_Text_197EF2, VictoryRoad_B2F_Text_197F46
-	msgbox VictoryRoad_B2F_Text_197F71, MSGBOX_AUTOCLOSE
+VictoryRoad_B2F_EventScript_Vito:: @ 815DFFB
+	trainerbattle_single TRAINER_VITO, VictoryRoad_B2F_Text_VitoIntro, VictoryRoad_B2F_Text_VitoDefeat
+	msgbox VictoryRoad_B2F_Text_VitoPostBattle, MSGBOX_AUTOCLOSE
 	end
 
-VictoryRoad_B2F_EventScript_15E012:: @ 815E012
-	trainerbattle_single TRAINER_OWEN, VictoryRoad_B2F_Text_197FE5, VictoryRoad_B2F_Text_19802B
-	msgbox VictoryRoad_B2F_Text_198047, MSGBOX_AUTOCLOSE
+VictoryRoad_B2F_EventScript_Owen:: @ 815E012
+	trainerbattle_single TRAINER_OWEN, VictoryRoad_B2F_Text_OwenIntro, VictoryRoad_B2F_Text_OwenDefeat
+	msgbox VictoryRoad_B2F_Text_OwenPostBattle, MSGBOX_AUTOCLOSE
 	end
 
-VictoryRoad_B2F_EventScript_15E029:: @ 815E029
-	trainerbattle_single TRAINER_CAROLINE, VictoryRoad_B2F_Text_198089, VictoryRoad_B2F_Text_1980AD
-	msgbox VictoryRoad_B2F_Text_1980C8, MSGBOX_AUTOCLOSE
+VictoryRoad_B2F_EventScript_Caroline:: @ 815E029
+	trainerbattle_single TRAINER_CAROLINE, VictoryRoad_B2F_Text_CarolineIntro, VictoryRoad_B2F_Text_CarolineDefeat
+	msgbox VictoryRoad_B2F_Text_CarolinePostBattle, MSGBOX_AUTOCLOSE
 	end
 
-VictoryRoad_B2F_EventScript_15E040:: @ 815E040
-	trainerbattle_single TRAINER_JULIE, VictoryRoad_B2F_Text_198121, VictoryRoad_B2F_Text_1981A3
-	msgbox VictoryRoad_B2F_Text_1981BA, MSGBOX_AUTOCLOSE
+VictoryRoad_B2F_EventScript_Julie:: @ 815E040
+	trainerbattle_single TRAINER_JULIE, VictoryRoad_B2F_Text_JulieIntro, VictoryRoad_B2F_Text_JulieDefeat
+	msgbox VictoryRoad_B2F_Text_JuliePostBattle, MSGBOX_AUTOCLOSE
 	end

--- a/data/maps/VictoryRoad_B2F/text.inc
+++ b/data/maps/VictoryRoad_B2F/text.inc
@@ -1,49 +1,49 @@
-VictoryRoad_B2F_Text_197EF2:: @ 8197EF2
+VictoryRoad_B2F_Text_VitoIntro:: @ 8197EF2
 	.string "I trained together with my whole family,\n"
 	.string "every one of us!\l"
 	.string "I'm not losing to anyone!$"
 
-VictoryRoad_B2F_Text_197F46:: @ 8197F46
+VictoryRoad_B2F_Text_VitoDefeat:: @ 8197F46
 	.string "Better than my family?!\n"
 	.string "Is that possible?!$"
 
-VictoryRoad_B2F_Text_197F71:: @ 8197F71
+VictoryRoad_B2F_Text_VitoPostBattle:: @ 8197F71
 	.string "I was better than everyone in my\n"
 	.string "family. I've never lost before...\p"
 	.string "I've lost my confidence...\n"
 	.string "Maybe I'll go home...$"
 
-VictoryRoad_B2F_Text_197FE5:: @ 8197FE5
+VictoryRoad_B2F_Text_OwenIntro:: @ 8197FE5
 	.string "I'd heard that there was a tough\n"
 	.string "little kid around. Do they mean you?$"
 
-VictoryRoad_B2F_Text_19802B:: @ 819802B
+VictoryRoad_B2F_Text_OwenDefeat:: @ 819802B
 	.string "The little shrimp is tough!$"
 
-VictoryRoad_B2F_Text_198047:: @ 8198047
+VictoryRoad_B2F_Text_OwenPostBattle:: @ 8198047
 	.string "The rumors I heard, that tough little\n"
 	.string "kid is from PETALBURG CITY.$"
 
-VictoryRoad_B2F_Text_198089:: @ 8198089
+VictoryRoad_B2F_Text_CarolineIntro:: @ 8198089
 	.string "You must be getting a little tired.$"
 
-VictoryRoad_B2F_Text_1980AD:: @ 81980AD
+VictoryRoad_B2F_Text_CarolineDefeat:: @ 81980AD
 	.string "No signs of tiring at all!$"
 
-VictoryRoad_B2F_Text_1980C8:: @ 81980C8
+VictoryRoad_B2F_Text_CarolinePostBattle:: @ 81980C8
 	.string "VICTORY ROAD and the POKéMON LEAGUE\n"
 	.string "are long and grueling challenges.\l"
 	.string "Beware of fatigue!$"
 
-VictoryRoad_B2F_Text_198121:: @ 8198121
+VictoryRoad_B2F_Text_JulieIntro:: @ 8198121
 	.string "You shouldn't get complacent just\n"
 	.string "because you have a lot of GYM BADGES.\p"
 	.string "There's always going to be someone\n"
 	.string "who's better than you!$"
 
-VictoryRoad_B2F_Text_1981A3:: @ 81981A3
+VictoryRoad_B2F_Text_JulieDefeat:: @ 81981A3
 	.string "You're better than me!$"
 
-VictoryRoad_B2F_Text_1981BA:: @ 81981BA
+VictoryRoad_B2F_Text_JuliePostBattle:: @ 81981BA
 	.string "Gaze on your collected BADGES and\n"
 	.string "remember the TRAINERS you've faced.$"


### PR DESCRIPTION
CHANGES: Names for EventScripts and Text have been modified to somewhat mimic those of PokeEmerald with a focus on readability and ease of understanding. New names have been created where needed.

TESTING DONE: "[version] COMPARE=1" for ruby, ruby_rev1, ruby_rev2, ruby_debug, sapphire, sapphire_rev1, sapphire_rev2, sapphire_debug.
"[version] COMPARE=1" for ruby_de, ruby_de_debug, sapphire_de, sapphire_de_debug as well.

NOTES: Very small contribution due to work and chores. Almost nothing is better than actually nothing!