### PR TITLE
Fix GBAFIX Usage in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,11 +221,12 @@ tidy:
 
 $(ROM): %.gba: %.elf
 	$(OBJCOPY) -O binary --gap-fill 0xFF --pad-to 0x9000000 $< $@
+	$(GBAFIX) $@ -p --silent
 
 %.elf: $(LD_SCRIPT) $(ALL_OBJECTS)
 	@echo "cd $(BUILD_DIR) && $(LD) -T $(LD_SCRIPT:$(BUILD_DIR)/%=%) -Map ../../$(MAP) -o ../../$@ <objects> <lib>"
 	@cd $(BUILD_DIR) && $(LD) -T $(LD_SCRIPT:$(BUILD_DIR)/%=%) -Map ../../$(MAP) -o ../../$@ $(OBJS_REL) $(LDFLAGS)
-	$(GBAFIX) $@ -p -t"$(TITLE)" -c$(GAME_CODE) -m$(MAKER_CODE) -r$(GAME_REVISION) --silent
+	$(GBAFIX) $@ -t"$(TITLE)" -c$(GAME_CODE) -m$(MAKER_CODE) -r$(GAME_REVISION) --silent
 
 $(LD_SCRIPT): $(LD_SCRIPT:$(BUILD_DIR)/%.ld=%.txt) $(BUILD_DIR)/sym_common.ld $(BUILD_DIR)/sym_ewram.ld $(BUILD_DIR)/sym_bss.ld
 	sed -e "s#tools/#../../tools/#g" $< >$@

--- a/tools/mapjson/json11.cpp
+++ b/tools/mapjson/json11.cpp
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstdio>
+#include <cstdint>
 #include <limits>
 
 namespace json11 {


### PR DESCRIPTION
Can't believe I'm making a PR to this godforsaken repo in the year of our lord 2025

Also corrects a missing include for mapjson; this was probably a transient include that changed between some versions of the standard library, not sure which exactly