### PR TITLE
10 year old Windows-specific(?) CRLF bug patch on tools\preproc

### DIFF
--- a/tools/preproc/asm_file.cpp
+++ b/tools/preproc/asm_file.cpp
@@ -668,7 +668,7 @@ void AsmFile::RaiseWarning(const char* format, ...)
 int AsmFile::SkipWhitespaceAndEol()
 {
     int newlines = 0;
-    while (m_buffer[m_pos] == '\t' || m_buffer[m_pos] == ' ' || m_buffer[m_pos] == '\n')
+    while (m_buffer[m_pos] == '\t' || m_buffer[m_pos] == ' ' || m_buffer[m_pos] == '\n' || m_buffer[m_pos] == '\r')
     {
         if (m_buffer[m_pos] == '\n')
             newlines++;


### PR DESCRIPTION
On Windows, arm-none-eabi-cpp emits CRLF line endings. SkipWhitespaceAndEol() only skipped '\n', leaving '\r' at the current position. This caused ParseEnum() to fail to read the first identifier of an enum and incorrectly report empty enum is invalid. Adding '\r' fixes parsing of CRLF input.